### PR TITLE
Add cryptography and build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /app
 
 # Install system dependencies that may be required by Python packages
 # e.g., for cryptography or other compiled libraries
-# RUN apt-get update && apt-get install -y build-essential libssl-dev
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy the requirements file first to leverage Docker layer caching
 COPY requirements.txt .

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ loguru
 
 # Testing (Task QA-01)
 pytest
+
+# Task instructions: add cryptography for SSL functionalities
+cryptography


### PR DESCRIPTION
### Task
- User request: Append `cryptography` to requirements and install build tools

### Description
- Added `cryptography` package requirement
- Updated `Dockerfile` to install `build-essential` and `libssl-dev`

### Checklist
- [x] Tests executed
- [x] Pre-commit hooks attempted


------
https://chatgpt.com/codex/tasks/task_e_686ba1303afc832a8c3d0e2837abdabc