### PR TITLE
Add Whisper warm-up script

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ TEL3SIS/
 │   ├── celery_app.py     # Celery factory
 │   └── state_manager.py  # Redis wrapper
 ├── tools/                # Calendar, Weather, SMS, etc.
-├── scripts/              # Dev helpers (e.g., dev_test_call.py)
+├── scripts/              # Dev helpers and startup tasks
 ├── tasks.yml             # Swarm task manifest
 ├── docker-compose.yml
 ├── Dockerfile
@@ -166,6 +166,7 @@ pytest -q
 
 * Unit tests live under `tests/`
 * End‑to‑end call emulation via `scripts/dev_test_call.py`
+* STT latency reduction via `scripts/warmup_whisper.py`
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
       - "3000:3000"
     # The actual command to run the Flask app will be added in a later task
     # For now, this keeps the service alive for inspection.
-    command: python -m http.server 3000
+    command: >-
+      bash -c "python scripts/warmup_whisper.py && python -m http.server 3000"
     depends_on:
       - redis
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ pytest
 
 # Task instructions: add cryptography for SSL functionalities
 cryptography
+
+# Speech-to-text
+openai-whisper

--- a/scripts/warmup_whisper.py
+++ b/scripts/warmup_whisper.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import time
+
+from loguru import logger
+import whisper
+
+
+MODEL: whisper.Whisper | None = None
+
+
+def load_model(model_name: str = "base") -> whisper.Whisper:
+    """Load and return a Whisper model, caching globally."""
+    global MODEL
+    if MODEL is None:
+        start = time.perf_counter()
+        logger.info("Loading Whisper model '%s'...", model_name)
+        MODEL = whisper.load_model(model_name)
+        elapsed = time.perf_counter() - start
+        logger.info("Whisper model loaded in %.2f seconds", elapsed)
+    return MODEL
+
+
+if __name__ == "__main__":
+    load_model()


### PR DESCRIPTION
### Task
- ID: 4 – INIT-03

### Description
Implemented a startup script that preloads an OpenAI Whisper model so the first call experiences lower STT latency. Docker Compose now executes this warm-up before starting the demo server. Added dependency and updated docs.

### Checklist
- [x] Tests added *(none required)*
- [x] Docs updated
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686bb01440a4832aba8c6cc5da13a4b6