### PR TITLE
CORE-04: enable Twilio recording

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ PyGithub
 
 # YAML parsing
 PyYAML
+requests

--- a/server/app.py
+++ b/server/app.py
@@ -22,6 +22,7 @@ def create_app() -> Flask:
     twilio_config = TwilioConfig(
         account_sid=os.environ.get("TWILIO_ACCOUNT_SID", ""),
         auth_token=os.environ.get("TWILIO_AUTH_TOKEN", ""),
+        record=True,
     )
 
     telephony_server = TelephonyServer(

--- a/server/recordings.py
+++ b/server/recordings.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import requests
+
+
+DEFAULT_OUTPUT_DIR = Path("recordings/audio")
+
+
+def download_recording(
+    url: str, *, output_dir: Path = DEFAULT_OUTPUT_DIR, auth: Tuple[str, str]
+) -> Path:
+    """Download a Twilio recording URL to the given directory.
+
+    Parameters
+    ----------
+    url: str
+        The Twilio recording URL, without file extension.
+    output_dir: Path, optional
+        Directory where the audio file will be saved. Defaults to ``recordings/audio``.
+    auth: Tuple[str, str]
+        Tuple of ``(account_sid, auth_token)`` for HTTP basic auth.
+
+    Returns
+    -------
+    Path
+        Path to the downloaded recording file.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    file_name = url.rstrip("/").split("/")[-1] + ".mp3"
+    file_path = output_dir / file_name
+    response = requests.get(f"{url}.mp3", auth=auth, timeout=10)
+    response.raise_for_status()
+    file_path.write_bytes(response.content)
+    return file_path


### PR DESCRIPTION
### Task
- ID: 9 – CORE-04
### Description
Enable call recordings by setting `record=True` on the Twilio configuration and add a utility to download recordings.
### Checklist
- [ ] Tests added
- [x] Docs updated
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686bda21f370832a94e570463ed9409e