### PR TITLE
Implement FWD-01 escalation keywords

### DIFF
--- a/server/escalation.py
+++ b/server/escalation.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable
+
+"""Utilities for escalation keyword detection."""
+
+if TYPE_CHECKING:  # pragma: no cover - for typing only
+    from .state_manager import StateManager
+
+ESCALATION_KEYWORDS: set[str] = {
+    "help",
+    "human",
+    "representative",
+    "operator",
+    "emergency",
+}
+
+
+def contains_keyword(text: str, keywords: Iterable[str] = ESCALATION_KEYWORDS) -> bool:
+    """Return ``True`` if the text contains any escalation keyword."""
+    lower = text.lower()
+    return any(kw.lower() in lower for kw in keywords)
+
+
+def check_and_flag(state_manager: "StateManager", call_sid: str, text: str) -> bool:
+    """Update session state if escalation is requested."""
+    if contains_keyword(text, ESCALATION_KEYWORDS):
+        state_manager.update_session(call_sid, escalation_required="true")
+        return True
+    return False

--- a/server/state_manager.py
+++ b/server/state_manager.py
@@ -93,6 +93,17 @@ class StateManager:
     def delete_token(self, user_id: str) -> None:
         self._redis.delete(self._token_key(user_id))
 
+    # --- Escalation Flags --------------------------------------------
+
+    def flag_escalation(self, call_sid: str) -> None:
+        """Mark that the call requires escalation."""
+        self.update_session(call_sid, escalation_required="true")
+
+    def is_escalation_required(self, call_sid: str) -> bool:
+        """Return ``True`` if escalation was requested for this call."""
+        value = self.get_session(call_sid).get("escalation_required")
+        return str(value).lower() == "true"
+
     # --- OAuth State -------------------------------------------------
 
     def set_oauth_state(self, state: str, user_id: str, ttl: int = 600) -> None:

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import fakeredis
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from server.state_manager import StateManager
+from server import escalation
+
+
+def _make_manager(monkeypatch: Any) -> StateManager:
+    key = AESGCM.generate_key(bit_length=128)
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(key).decode())
+    manager = StateManager(url="redis://localhost:6379/0")
+    manager._redis = fakeredis.FakeRedis(decode_responses=True)
+    return manager
+
+
+def test_contains_keyword() -> None:
+    assert escalation.contains_keyword("This is an emergency situation")
+    assert not escalation.contains_keyword("just chatting")
+
+
+def test_check_and_flag(monkeypatch: Any) -> None:
+    manager = _make_manager(monkeypatch)
+    manager.create_session("call", {"foo": "bar"})
+    flagged = escalation.check_and_flag(manager, "call", "I need a human operator")
+    assert flagged
+    assert manager.is_escalation_required("call")


### PR DESCRIPTION
### Task
- ID: 18 – FWD-01

### Description
Adds basic keyword detection for call escalation. The new `server/escalation.py` module maintains the list of escalation keywords and flags sessions via `StateManager`. Tests cover keyword checks and state flagging.

### Checklist
- [x] Tests added
- [x] Docs updated
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686c30bc7b00832ab82040f4f7dafbce