### PR TITLE
Add conversation summary on escalation

### DIFF
--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -29,3 +29,13 @@ def test_check_and_flag(monkeypatch: Any) -> None:
     flagged = escalation.check_and_flag(manager, "call", "I need a human operator")
     assert flagged
     assert manager.is_escalation_required("call")
+
+
+def test_summarize_conversation(monkeypatch: Any) -> None:
+    manager = _make_manager(monkeypatch)
+    manager.create_session("call", {"init": "1"})
+    manager.append_history("call", "user", "hello there")
+    manager.append_history("call", "bot", "hi how can I help")
+    summary = escalation.summarize_conversation(manager, "call", max_words=5)
+    assert "hello" in summary
+    assert manager.get_summary("call") == summary

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -31,3 +31,14 @@ def test_oauth_state(monkeypatch):
     manager.set_oauth_state("abc", "user1", ttl=1)
     assert manager.pop_oauth_state("abc") == "user1"
     assert manager.pop_oauth_state("abc") is None
+
+
+def test_history_and_summary(monkeypatch: Any) -> None:
+    manager = _make_manager(monkeypatch)
+    manager.create_session("call", {"init": "1"})
+    manager.append_history("call", "user", "hi there")
+    manager.append_history("call", "bot", "hello")
+    history = manager.get_history("call")
+    assert history[0]["text"] == "hi there"
+    manager.set_summary("call", "greeting")
+    assert manager.get_summary("call") == "greeting"


### PR DESCRIPTION
## Summary
- store conversation history in `StateManager`
- generate summary when escalation keywords detected
- expose helper methods for call history
- test summarization and history CRUD

## Testing
- `pre-commit run --files server/state_manager.py server/escalation.py tests/test_escalation.py tests/test_state_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c36ba8130832aa7c61b468263c11e