### PR TITLE
Implement call listing blueprint

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -10,6 +10,7 @@ from vocode.streaming.telephony.server.base import (
     TwilioInboundCallConfig,
 )
 from .handoff import dial_twiml
+from .calls_bp import bp as calls_bp
 from vocode.streaming.telephony.config_manager.in_memory_config_manager import (
     InMemoryConfigManager,
 )
@@ -24,6 +25,7 @@ from tools.calendar import generate_auth_url, exchange_code
 def create_app() -> Flask:
     """Create and configure the Flask application."""
     app = Flask(__name__)
+    app.register_blueprint(calls_bp)
     init_db()
 
     base_url = os.environ.get("BASE_URL", "")

--- a/server/calls_bp.py
+++ b/server/calls_bp.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from flask import Blueprint, jsonify
+
+from .database import Call, get_session
+
+
+bp = Blueprint("calls", __name__)
+
+
+@bp.get("/calls")
+def list_calls() -> str:  # type: ignore[return-type]
+    """Return JSON list of recorded calls."""
+    with get_session() as session:
+        calls = session.query(Call).order_by(Call.created_at.desc()).all()
+        data = [
+            {
+                "id": c.id,
+                "call_sid": c.call_sid,
+                "from_number": c.from_number,
+                "to_number": c.to_number,
+                "transcript_path": c.transcript_path,
+                "summary": c.summary,
+                "self_critique": c.self_critique,
+                "created_at": c.created_at.isoformat(),
+            }
+            for c in calls
+        ]
+    return jsonify(data)

--- a/tests/test_calls_blueprint.py
+++ b/tests/test_calls_blueprint.py
@@ -1,0 +1,145 @@
+import types
+import sys
+from importlib import reload
+
+# Reuse the dummy vocode modules from test_metrics
+
+# Provide dummy "vocode" modules so that server.app can be imported without the real dependency.
+dummy = types.ModuleType("vocode")
+dummy.streaming = types.ModuleType("vocode.streaming")
+dummy.streaming.agent = types.ModuleType("vocode.streaming.agent")
+dummy.streaming.agent.chat_gpt_agent = types.ModuleType(
+    "vocode.streaming.agent.chat_gpt_agent"
+)
+dummy.streaming.agent.base_agent = types.ModuleType("vocode.streaming.agent.base_agent")
+dummy.streaming.agent.default_factory = types.ModuleType(
+    "vocode.streaming.agent.default_factory"
+)
+dummy.streaming.telephony = types.ModuleType("vocode.streaming.telephony")
+dummy.streaming.telephony.server = types.ModuleType("vocode.streaming.telephony.server")
+dummy.streaming.telephony.server.base = types.ModuleType(
+    "vocode.streaming.telephony.server.base"
+)
+dummy.streaming.telephony.config_manager = types.ModuleType(
+    "vocode.streaming.telephony.config_manager"
+)
+dummy.streaming.telephony.config_manager.in_memory_config_manager = types.ModuleType(
+    "vocode.streaming.telephony.config_manager.in_memory_config_manager"
+)
+dummy.streaming.models = types.ModuleType("vocode.streaming.models")
+dummy.streaming.models.agent = types.ModuleType("vocode.streaming.models.agent")
+dummy.streaming.models.actions = types.ModuleType("vocode.streaming.models.actions")
+dummy.streaming.models.message = types.ModuleType("vocode.streaming.models.message")
+dummy.streaming.models.transcriber = types.ModuleType(
+    "vocode.streaming.models.transcriber"
+)
+dummy.streaming.models.synthesizer = types.ModuleType(
+    "vocode.streaming.models.synthesizer"
+)
+dummy.streaming.models.telephony = types.ModuleType("vocode.streaming.models.telephony")
+
+
+class Dummy:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+
+dummy.streaming.agent.chat_gpt_agent.ChatGPTAgent = Dummy
+dummy.streaming.agent.base_agent.AgentInput = Dummy
+dummy.streaming.agent.base_agent.AgentResponseMessage = Dummy
+dummy.streaming.agent.base_agent.GeneratedResponse = Dummy
+dummy.streaming.agent.base_agent.BaseAgent = Dummy
+dummy.streaming.agent.default_factory.DefaultAgentFactory = Dummy
+dummy.streaming.models.agent.AgentConfig = Dummy
+dummy.streaming.models.agent.ChatGPTAgentConfig = Dummy
+dummy.streaming.models.actions.FunctionCall = Dummy
+dummy.streaming.models.message.BaseMessage = Dummy
+dummy.streaming.models.message.EndOfTurn = Dummy
+dummy.streaming.models.transcriber.WhisperCPPTranscriberConfig = Dummy
+dummy.streaming.models.synthesizer.ElevenLabsSynthesizerConfig = Dummy
+
+
+class TelephonyServer:
+    def __init__(self, *_: object, **__: object) -> None:
+        pass
+
+    def create_inbound_route(self, *_: object, **__: object):
+        async def dummy_route(**___: object):
+            return type(
+                "Resp",
+                (),
+                {"body": b"", "status_code": 200, "media_type": "text/plain"},
+            )
+
+        return dummy_route
+
+
+class TwilioInboundCallConfig:
+    def __init__(self, **__: object) -> None:
+        pass
+
+
+class InMemoryConfigManager:
+    pass
+
+
+class TwilioConfig:
+    def __init__(self, **__: object) -> None:
+        pass
+
+
+dummy.streaming.telephony.server.base.TelephonyServer = TelephonyServer
+dummy.streaming.telephony.server.base.TwilioInboundCallConfig = TwilioInboundCallConfig
+dummy.streaming.telephony.config_manager.in_memory_config_manager.InMemoryConfigManager = (
+    InMemoryConfigManager
+)
+dummy.streaming.models.telephony.TwilioConfig = TwilioConfig
+
+sys.modules["vocode"] = dummy
+sys.modules["vocode.streaming"] = dummy.streaming
+sys.modules["vocode.streaming.agent"] = dummy.streaming.agent
+sys.modules[
+    "vocode.streaming.agent.chat_gpt_agent"
+] = dummy.streaming.agent.chat_gpt_agent
+sys.modules["vocode.streaming.agent.base_agent"] = dummy.streaming.agent.base_agent
+sys.modules[
+    "vocode.streaming.agent.default_factory"
+] = dummy.streaming.agent.default_factory
+sys.modules["vocode.streaming.telephony"] = dummy.streaming.telephony
+sys.modules["vocode.streaming.telephony.server"] = dummy.streaming.telephony.server
+sys.modules[
+    "vocode.streaming.telephony.server.base"
+] = dummy.streaming.telephony.server.base
+sys.modules[
+    "vocode.streaming.telephony.config_manager"
+] = dummy.streaming.telephony.config_manager
+sys.modules[
+    "vocode.streaming.telephony.config_manager.in_memory_config_manager"
+] = dummy.streaming.telephony.config_manager.in_memory_config_manager
+sys.modules["vocode.streaming.models"] = dummy.streaming.models
+sys.modules["vocode.streaming.models.agent"] = dummy.streaming.models.agent
+sys.modules["vocode.streaming.models.actions"] = dummy.streaming.models.actions
+sys.modules["vocode.streaming.models.message"] = dummy.streaming.models.message
+sys.modules["vocode.streaming.models.transcriber"] = dummy.streaming.models.transcriber
+sys.modules["vocode.streaming.models.synthesizer"] = dummy.streaming.models.synthesizer
+sys.modules["vocode.streaming.models.telephony"] = dummy.streaming.models.telephony
+
+
+from server import database as db  # noqa: E402
+from server.app import create_app  # noqa: E402
+
+
+def test_list_calls(monkeypatch, tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    reload(db)
+    db.init_db()
+    db.save_call_summary("abc", "111", "222", "/path", "summary", "crit")
+
+    app = create_app()
+    client = app.test_client()
+
+    resp = client.get("/calls")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data[0]["call_sid"] == "abc"


### PR DESCRIPTION
### Task
- Create blueprint to list recorded calls

### Description
- Added `server/calls_bp.py` with a `/calls` endpoint returning call metadata from the database
- Registered blueprint within `create_app`
- Added unit test `test_calls_blueprint.py`

### Checklist
- [x] Tests added
- [x] Docs updated (N/A)
- [x] CI green

------
https://chatgpt.com/codex/tasks/task_e_686cdf67aca8832ab6e693cd7778b800