### PR TITLE
Add dashboard with audio playback

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -11,6 +11,7 @@ from vocode.streaming.telephony.server.base import (
 )
 from .handoff import dial_twiml
 from .calls_bp import bp as calls_bp
+from .dashboard_bp import bp as dashboard_bp
 from vocode.streaming.telephony.config_manager.in_memory_config_manager import (
     InMemoryConfigManager,
 )
@@ -26,6 +27,7 @@ def create_app() -> Flask:
     """Create and configure the Flask application."""
     app = Flask(__name__)
     app.register_blueprint(calls_bp)
+    app.register_blueprint(dashboard_bp)
     init_db()
 
     base_url = os.environ.get("BASE_URL", "")

--- a/server/templates/dashboard/detail.html
+++ b/server/templates/dashboard/detail.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<title>Call Detail</title>
+<h1>Call {{ call.call_sid }}</h1>
+<p>From: {{ call.from_number }} → {{ call.to_number }}</p>
+<p>Summary: {{ call.summary }}</p>
+{% if call.self_critique %}
+<p>Self Critique: {{ call.self_critique }}</p>
+{% endif %}
+<audio controls src="{{ audio_path }}"></audio>
+<pre>{{ transcript }}</pre>
+<p><a href="{{ url_for('dashboard.show_dashboard') }}">Back</a></p>

--- a/server/templates/dashboard/list.html
+++ b/server/templates/dashboard/list.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<title>Call Dashboard</title>
+<h1>Call History</h1>
+<form method="get">
+  <input type="text" name="q" placeholder="Search" value="{{ q }}" />
+  <button type="submit">Search</button>
+</form>
+<ul>
+{% for call in calls %}
+  <li>
+    <a href="{{ url_for('dashboard.call_detail', call_id=call.id) }}">
+      {{ call.created_at.strftime('%Y-%m-%d %H:%M') }} - {{ call.from_number }} → {{ call.to_number }}
+    </a>
+  </li>
+{% else %}
+  <li>No calls found.</li>
+{% endfor %}
+</ul>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,153 @@
+import types
+import sys
+from importlib import reload
+
+# Provide dummy "vocode" modules so that server.app can be imported without the real dependency.
+dummy = types.ModuleType("vocode")
+dummy.streaming = types.ModuleType("vocode.streaming")
+dummy.streaming.agent = types.ModuleType("vocode.streaming.agent")
+dummy.streaming.agent.chat_gpt_agent = types.ModuleType(
+    "vocode.streaming.agent.chat_gpt_agent"
+)
+dummy.streaming.agent.base_agent = types.ModuleType("vocode.streaming.agent.base_agent")
+dummy.streaming.agent.default_factory = types.ModuleType(
+    "vocode.streaming.agent.default_factory"
+)
+dummy.streaming.telephony = types.ModuleType("vocode.streaming.telephony")
+dummy.streaming.telephony.server = types.ModuleType("vocode.streaming.telephony.server")
+dummy.streaming.telephony.server.base = types.ModuleType(
+    "vocode.streaming.telephony.server.base"
+)
+dummy.streaming.telephony.config_manager = types.ModuleType(
+    "vocode.streaming.telephony.config_manager"
+)
+dummy.streaming.telephony.config_manager.in_memory_config_manager = types.ModuleType(
+    "vocode.streaming.telephony.config_manager.in_memory_config_manager"
+)
+dummy.streaming.models = types.ModuleType("vocode.streaming.models")
+dummy.streaming.models.agent = types.ModuleType("vocode.streaming.models.agent")
+dummy.streaming.models.actions = types.ModuleType("vocode.streaming.models.actions")
+dummy.streaming.models.message = types.ModuleType("vocode.streaming.models.message")
+dummy.streaming.models.transcriber = types.ModuleType(
+    "vocode.streaming.models.transcriber"
+)
+dummy.streaming.models.synthesizer = types.ModuleType(
+    "vocode.streaming.models.synthesizer"
+)
+dummy.streaming.models.telephony = types.ModuleType("vocode.streaming.models.telephony")
+
+
+class Dummy:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+
+dummy.streaming.agent.chat_gpt_agent.ChatGPTAgent = Dummy
+dummy.streaming.agent.base_agent.AgentInput = Dummy
+dummy.streaming.agent.base_agent.AgentResponseMessage = Dummy
+dummy.streaming.agent.base_agent.GeneratedResponse = Dummy
+dummy.streaming.agent.base_agent.BaseAgent = Dummy
+dummy.streaming.agent.default_factory.DefaultAgentFactory = Dummy
+dummy.streaming.models.agent.AgentConfig = Dummy
+dummy.streaming.models.agent.ChatGPTAgentConfig = Dummy
+dummy.streaming.models.actions.FunctionCall = Dummy
+dummy.streaming.models.message.BaseMessage = Dummy
+dummy.streaming.models.message.EndOfTurn = Dummy
+dummy.streaming.models.transcriber.WhisperCPPTranscriberConfig = Dummy
+dummy.streaming.models.synthesizer.ElevenLabsSynthesizerConfig = Dummy
+
+
+class TelephonyServer:
+    def __init__(self, *_: object, **__: object) -> None:
+        pass
+
+    def create_inbound_route(self, *_: object, **__: object):
+        async def dummy_route(**___: object):
+            return type(
+                "Resp",
+                (),
+                {"body": b"", "status_code": 200, "media_type": "text/plain"},
+            )
+
+        return dummy_route
+
+
+class TwilioInboundCallConfig:
+    def __init__(self, **__: object) -> None:
+        pass
+
+
+class InMemoryConfigManager:
+    pass
+
+
+class TwilioConfig:
+    def __init__(self, **__: object) -> None:
+        pass
+
+
+dummy.streaming.telephony.server.base.TelephonyServer = TelephonyServer
+dummy.streaming.telephony.server.base.TwilioInboundCallConfig = TwilioInboundCallConfig
+dummy.streaming.telephony.config_manager.in_memory_config_manager.InMemoryConfigManager = (
+    InMemoryConfigManager
+)
+dummy.streaming.models.telephony.TwilioConfig = TwilioConfig
+
+sys.modules["vocode"] = dummy
+sys.modules["vocode.streaming"] = dummy.streaming
+sys.modules["vocode.streaming.agent"] = dummy.streaming.agent
+sys.modules[
+    "vocode.streaming.agent.chat_gpt_agent"
+] = dummy.streaming.agent.chat_gpt_agent
+sys.modules["vocode.streaming.agent.base_agent"] = dummy.streaming.agent.base_agent
+sys.modules[
+    "vocode.streaming.agent.default_factory"
+] = dummy.streaming.agent.default_factory
+sys.modules["vocode.streaming.telephony"] = dummy.streaming.telephony
+sys.modules["vocode.streaming.telephony.server"] = dummy.streaming.telephony.server
+sys.modules[
+    "vocode.streaming.telephony.server.base"
+] = dummy.streaming.telephony.server.base
+sys.modules[
+    "vocode.streaming.telephony.config_manager"
+] = dummy.streaming.telephony.config_manager
+sys.modules[
+    "vocode.streaming.telephony.config_manager.in_memory_config_manager"
+] = dummy.streaming.telephony.config_manager.in_memory_config_manager
+sys.modules["vocode.streaming.models"] = dummy.streaming.models
+sys.modules["vocode.streaming.models.agent"] = dummy.streaming.models.agent
+sys.modules["vocode.streaming.models.actions"] = dummy.streaming.models.actions
+sys.modules["vocode.streaming.models.message"] = dummy.streaming.models.message
+sys.modules["vocode.streaming.models.transcriber"] = dummy.streaming.models.transcriber
+sys.modules["vocode.streaming.models.synthesizer"] = dummy.streaming.models.synthesizer
+sys.modules["vocode.streaming.models.telephony"] = dummy.streaming.models.telephony
+
+from server import database as db  # noqa: E402
+from server.app import create_app  # noqa: E402
+
+
+def test_dashboard_pages(monkeypatch, tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    reload(db)
+    db.init_db()
+    transcript_dir = tmp_path / "transcripts"
+    transcript_dir.mkdir()
+    transcript_path = transcript_dir / "test.txt"
+    transcript_path.write_text("hello world")
+    db.save_call_summary("abc", "111", "222", str(transcript_path), "summary", "crit")
+
+    app = create_app()
+    client = app.test_client()
+
+    resp = client.get("/dashboard")
+    assert resp.status_code == 200
+    assert b"111" in resp.data
+
+    resp = client.get("/dashboard?q=111")
+    assert resp.status_code == 200
+    assert b"111" in resp.data
+
+    resp = client.get("/dashboard/1")
+    assert resp.status_code == 200
+    assert b"hello world" in resp.data


### PR DESCRIPTION
### Task
- ID: 28 – UI-02

### Description
Adds a simple Flask dashboard that lists calls, supports searching by query
parameter, and provides a detailed view page with transcript and audio player.

### Checklist
- [x] Tests added
- [x] Docs updated
- [x] CI green

------
https://chatgpt.com/codex/tasks/task_e_686ce2d74078832a80bedadecc8c6a24