### PR TITLE
Implement MEM-04 summarization memory

### DIFF
--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -6,19 +6,22 @@ from typing import Any
 import fakeredis
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
+from pathlib import Path
+
 from server.state_manager import StateManager
 
 
-def _make_manager(monkeypatch: Any) -> StateManager:
+def _make_manager(monkeypatch: Any, tmp_path: Path) -> StateManager:
     key = AESGCM.generate_key(bit_length=128)
     monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(key).decode())
+    monkeypatch.setenv("VECTOR_DB_PATH", str(tmp_path / "vectors"))
     manager = StateManager(url="redis://localhost:6379/0")
     manager._redis = fakeredis.FakeRedis(decode_responses=True)
     return manager
 
 
-def test_token_crud(monkeypatch):
-    manager = _make_manager(monkeypatch)
+def test_token_crud(monkeypatch, tmp_path):
+    manager = _make_manager(monkeypatch, tmp_path)
     manager.set_token("user1", "at", "rt", expires_at=123)
     data = manager.get_token("user1")
     assert data == {"access_token": "at", "refresh_token": "rt", "expires_at": "123"}
@@ -26,15 +29,15 @@ def test_token_crud(monkeypatch):
     assert manager.get_token("user1") is None
 
 
-def test_oauth_state(monkeypatch):
-    manager = _make_manager(monkeypatch)
+def test_oauth_state(monkeypatch, tmp_path):
+    manager = _make_manager(monkeypatch, tmp_path)
     manager.set_oauth_state("abc", "user1", ttl=1)
     assert manager.pop_oauth_state("abc") == "user1"
     assert manager.pop_oauth_state("abc") is None
 
 
-def test_history_and_summary(monkeypatch: Any) -> None:
-    manager = _make_manager(monkeypatch)
+def test_history_and_summary(monkeypatch: Any, tmp_path: Path) -> None:
+    manager = _make_manager(monkeypatch, tmp_path)
     manager.create_session("call", {"init": "1"})
     manager.append_history("call", "user", "hi there")
     manager.append_history("call", "bot", "hello")
@@ -42,3 +45,11 @@ def test_history_and_summary(monkeypatch: Any) -> None:
     assert history[0]["text"] == "hi there"
     manager.set_summary("call", "greeting")
     assert manager.get_summary("call") == "greeting"
+
+
+def test_similar_summaries(monkeypatch: Any, tmp_path: Path) -> None:
+    manager = _make_manager(monkeypatch, tmp_path)
+    manager.set_summary("c1", "User asked about the weather forecast")
+    manager.set_summary("c2", "Discussion on holiday plans")
+    sims = manager.get_similar_summaries("weather", n_results=2)
+    assert "User asked about the weather forecast" in sims

--- a/tests/test_vector_db.py
+++ b/tests/test_vector_db.py
@@ -8,3 +8,10 @@ def test_add_and_search(tmp_path):
     db.add_texts(["hello world", "goodbye"])
     results = db.search("hello world", n_results=1)
     assert results[0] == "hello world"
+
+
+def test_summary_collection(tmp_path):
+    db = VectorDB(persist_directory=str(tmp_path), collection_name="summaries")
+    db.add_texts(["ask about weather"], ids=["c1"])
+    result = db.search("weather", n_results=1)
+    assert result[0] == "ask about weather"


### PR DESCRIPTION
### Task
- ID: 56 – MEM-04

### Description
Adds vector-based storage for call summaries. `StateManager` now indexes every
summary and retrieves similar ones when a session is created. Tests cover the
new functionality.

### Checklist
- [x] Tests added
- [x] Docs updated
- [x] CI green

------
https://chatgpt.com/codex/tasks/task_e_686d397196ec832aba2fe66fdc7a83c8