### PR TITLE
Add cleanup task and Celery beat schedule

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,16 @@ services:
     depends_on:
       - redis
 
+  celerybeat:
+    build: .
+    command: celery -A server.celery_app beat --loglevel=info
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    depends_on:
+      - redis
+
   # Grafana service for metrics dashboards
   grafana:
     image: grafana/grafana:9.5.3

--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from celery import Celery
+from celery.schedules import crontab
 
 
 def create_celery_app() -> Celery:
@@ -13,6 +14,12 @@ def create_celery_app() -> Celery:
     celery = Celery("tel3sis", broker=broker, backend=backend)
 
     celery.conf.task_routes = {"server.tasks.*": {"queue": "default"}}
+    celery.conf.beat_schedule = {
+        "cleanup-old-calls": {
+            "task": "server.tasks.cleanup_old_calls",
+            "schedule": crontab(minute=0, hour=0),
+        }
+    }
     return celery
 
 

--- a/server/tasks.py
+++ b/server/tasks.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from celery.utils.log import get_task_logger
 from pathlib import Path
 
-from .recordings import transcribe_recording
+from datetime import datetime, timedelta
+from .recordings import transcribe_recording, DEFAULT_OUTPUT_DIR
 from tools.notifications import send_email
-from .database import save_call_summary
+from .database import save_call_summary, get_session, Call
 from .self_reflection import generate_self_critique
 
 from .celery_app import celery_app
@@ -57,3 +58,22 @@ def transcribe_audio(
 def send_transcript_email(transcript_path: str, to_email: str | None = None) -> None:
     """Send the transcript file via email."""
     send_email(transcript_path, to_email)
+
+
+@celery_app.task
+def cleanup_old_calls(days: int = 30) -> int:
+    """Delete call records and files older than ``days`` days."""
+
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    removed = 0
+    with get_session() as session:
+        old_calls = session.query(Call).filter(Call.created_at < cutoff).all()
+        for call in old_calls:
+            transcript = Path(call.transcript_path)
+            audio = DEFAULT_OUTPUT_DIR / f"{transcript.stem}.mp3"
+            transcript.unlink(missing_ok=True)
+            audio.unlink(missing_ok=True)
+            session.delete(call)
+            removed += 1
+        session.commit()
+    return removed

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from importlib import reload
+from datetime import datetime, timedelta
+
+import server.database as db
+import server.tasks as tasks
+
+
+def test_cleanup_old_calls(monkeypatch, tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    reload(db)
+    db.init_db()
+
+    audio_dir = tmp_path / "audio"
+    transcript_dir = tmp_path / "transcripts"
+    audio_dir.mkdir()
+    transcript_dir.mkdir()
+
+    monkeypatch.setattr(tasks, "DEFAULT_OUTPUT_DIR", audio_dir)
+
+    old_transcript = transcript_dir / "old.txt"
+    old_audio = audio_dir / "old.mp3"
+    old_transcript.write_text("old")
+    old_audio.write_text("a")
+    old_date = datetime.utcnow() - timedelta(days=31)
+
+    with db.get_session() as session:
+        session.add(
+            db.Call(
+                call_sid="old",
+                from_number="111",
+                to_number="222",
+                transcript_path=str(old_transcript),
+                summary="s",
+                self_critique=None,
+                created_at=old_date,
+            )
+        )
+        session.commit()
+
+    new_transcript = transcript_dir / "new.txt"
+    new_audio = audio_dir / "new.mp3"
+    new_transcript.write_text("new")
+    new_audio.write_text("a")
+    new_date = datetime.utcnow() - timedelta(days=5)
+
+    with db.get_session() as session:
+        session.add(
+            db.Call(
+                call_sid="new",
+                from_number="111",
+                to_number="222",
+                transcript_path=str(new_transcript),
+                summary="s",
+                self_critique=None,
+                created_at=new_date,
+            )
+        )
+        session.commit()
+
+    reload(tasks)
+    monkeypatch.setattr(tasks, "DEFAULT_OUTPUT_DIR", audio_dir)
+
+    removed = tasks.cleanup_old_calls.run(days=30)
+    assert removed == 1
+    assert not old_transcript.exists()
+    assert not old_audio.exists()
+    assert new_transcript.exists()
+    assert new_audio.exists()
+    with db.get_session() as session:
+        calls = session.query(db.Call).all()
+        assert len(calls) == 1
+        assert calls[0].call_sid == "new"


### PR DESCRIPTION
### Task
- Implements periodic cleanup of old call data

### Description
- added daily Celery beat schedule
- created `cleanup_old_calls` task removing audio, transcripts and DB rows older than 30 days
- added Celery beat service to docker-compose
- included unit tests for cleanup logic

### Checklist
- [x] Tests added
- [x] Docs updated
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686d40b0a288832aa2395b0919e74cd9