### PR TITLE
Implement strict TOKEN_ENCRYPTION_KEY requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ python server/app.py
 | `NOTIFY_EMAIL` | Recipient for call transcripts |
 | _see `.env.example`_ |
 
+### Generating and Storing the Encryption Key
+
+The `TOKEN_ENCRYPTION_KEY` must be a persistent 128‑bit AES key encoded in
+base64. Generate one using:
+
+```bash
+python - <<'EOF'
+import base64, os
+print(base64.b64encode(os.urandom(16)).decode())
+EOF
+```
+
+Add the resulting value to your `.env` file under `TOKEN_ENCRYPTION_KEY` before
+starting the server. Without this key, TEL3SIS will refuse to launch.
+
 ---
 
 ## 🛠️ Development Workflow

--- a/server/app.py
+++ b/server/app.py
@@ -61,7 +61,10 @@ def create_app() -> Flask:
         config_manager=InMemoryConfigManager(),
         agent_factory=SafeAgentFactory(),
     )
-    state_manager = StateManager()
+    try:
+        state_manager = StateManager()
+    except ConfigError as exc:
+        raise RuntimeError(str(exc)) from exc
 
     @app.get("/oauth/start")
     def oauth_start() -> str:

--- a/tests/test_calls_blueprint.py
+++ b/tests/test_calls_blueprint.py
@@ -1,6 +1,7 @@
 import types
 import sys
 import os
+import base64
 from importlib import reload
 
 # Reuse the dummy vocode modules from test_metrics
@@ -129,6 +130,7 @@ os.environ.setdefault("SECRET_KEY", "x")
 os.environ.setdefault("BASE_URL", "http://localhost")
 os.environ.setdefault("TWILIO_ACCOUNT_SID", "sid")
 os.environ.setdefault("TWILIO_AUTH_TOKEN", "token")
+os.environ.setdefault("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
 
 
 from server import database as db  # noqa: E402
@@ -142,6 +144,7 @@ def test_list_calls(monkeypatch, tmp_path):
     monkeypatch.setenv("BASE_URL", "http://localhost")
     monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
     monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
     reload(db)
     db.init_db()
     db.save_call_summary("abc", "111", "222", "/path", "summary", "crit")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import types
 import sys
 import os
+import base64
 import pytest
 
 # Dummy modules to allow importing server.app without dependencies
@@ -128,6 +129,7 @@ os.environ.setdefault("SECRET_KEY", "x")
 os.environ.setdefault("BASE_URL", "http://localhost")
 os.environ.setdefault("TWILIO_ACCOUNT_SID", "sid")
 os.environ.setdefault("TWILIO_AUTH_TOKEN", "token")
+os.environ.setdefault("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
 
 
 from server.config import Config, ConfigError  # noqa: E402
@@ -148,5 +150,11 @@ def test_create_app_missing_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("BASE_URL", raising=False)
     monkeypatch.delenv("TWILIO_ACCOUNT_SID", raising=False)
     monkeypatch.delenv("TWILIO_AUTH_TOKEN", raising=False)
+    with pytest.raises(RuntimeError):
+        create_app()
+
+
+def test_create_app_missing_token_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TOKEN_ENCRYPTION_KEY", raising=False)
     with pytest.raises(RuntimeError):
         create_app()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,6 +1,7 @@
 import types
 import sys
 import os
+import base64
 from importlib import reload
 
 # Provide dummy "vocode" modules so that server.app can be imported without the real dependency.
@@ -127,6 +128,7 @@ os.environ.setdefault("SECRET_KEY", "x")
 os.environ.setdefault("BASE_URL", "http://localhost")
 os.environ.setdefault("TWILIO_ACCOUNT_SID", "sid")
 os.environ.setdefault("TWILIO_AUTH_TOKEN", "token")
+os.environ.setdefault("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
 
 from server import database as db  # noqa: E402
 from server.app import create_app  # noqa: E402
@@ -139,6 +141,7 @@ def test_dashboard_oauth_flow(monkeypatch, tmp_path):
     monkeypatch.setenv("BASE_URL", "http://localhost")
     monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
     monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
     reload(db)
     db.init_db()
     db.create_user("admin", "pass", role="admin")

--- a/tests/test_e2e_call.py
+++ b/tests/test_e2e_call.py
@@ -1,6 +1,7 @@
 import os
 import types
 import sys
+import base64
 from importlib import reload
 from pathlib import Path
 
@@ -133,6 +134,7 @@ os.environ.setdefault("SECRET_KEY", "x")
 os.environ.setdefault("BASE_URL", "http://localhost")
 os.environ.setdefault("TWILIO_ACCOUNT_SID", "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
 os.environ.setdefault("TWILIO_AUTH_TOKEN", "your_auth_token")
+os.environ.setdefault("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
 
 from server import app as server_app  # noqa: E402
 from server import database as db  # noqa: E402
@@ -147,6 +149,7 @@ def test_full_call_flow(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     monkeypatch.setenv("BASE_URL", "http://localhost")
     monkeypatch.setenv("TWILIO_ACCOUNT_SID", "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
     monkeypatch.setenv("TWILIO_AUTH_TOKEN", "your_auth_token")
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
     monkeypatch.setenv("ESCALATION_PHONE_NUMBER", "+15550001111")
     reload(db)
     db.init_db()

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as ET
 import types
 import sys
 import os
+import base64
 from importlib import reload
 
 from server.handoff import dial_twiml
@@ -132,6 +133,7 @@ os.environ.setdefault("SECRET_KEY", "x")
 os.environ.setdefault("BASE_URL", "http://localhost")
 os.environ.setdefault("TWILIO_ACCOUNT_SID", "sid")
 os.environ.setdefault("TWILIO_AUTH_TOKEN", "token")
+os.environ.setdefault("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
 
 
 def test_dial_twiml(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -193,6 +195,7 @@ def test_inbound_call_escalation(monkeypatch: pytest.MonkeyPatch, tmp_path) -> N
     monkeypatch.setenv("BASE_URL", "http://localhost")
     monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
     monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
 
     app = server_app.create_app()
     client = app.test_client()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,6 +2,7 @@ import sys
 import types
 import time
 import os
+import base64
 
 from server.latency_logging import log_stt
 
@@ -131,6 +132,7 @@ os.environ.setdefault("SECRET_KEY", "x")
 os.environ.setdefault("BASE_URL", "http://localhost")
 os.environ.setdefault("TWILIO_ACCOUNT_SID", "sid")
 os.environ.setdefault("TWILIO_AUTH_TOKEN", "token")
+os.environ.setdefault("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
 
 
 from server.app import create_app  # noqa: E402
@@ -141,6 +143,7 @@ def test_metrics_endpoint() -> None:
     os.environ.setdefault("BASE_URL", "http://localhost")
     os.environ.setdefault("TWILIO_ACCOUNT_SID", "sid")
     os.environ.setdefault("TWILIO_AUTH_TOKEN", "token")
+    os.environ.setdefault("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
     app = create_app()
     client = app.test_client()
 


### PR DESCRIPTION
### Task
- ID: 47 – CORE-17

### Description
- StateManager now raises `ConfigError` if `TOKEN_ENCRYPTION_KEY` is unset or malformed.
- `create_app` converts that error to `RuntimeError`.
- README documents generating and storing the encryption key.
- Tests updated and added to verify startup fails without the key.

### Checklist
- [x] Tests added
- [x] Docs updated
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686d481f31a0832a89d90437b6623fa1