### PR TITLE
CORE-47 enforce encryption key

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ EOF
 ```
 
 Add the resulting value to your `.env` file under `TOKEN_ENCRYPTION_KEY` before
-starting the server. Without this key, TEL3SIS will refuse to launch.
+starting the server. The decoded key must be exactly 16 bytes (AES‑128).
+Without this key, TEL3SIS will refuse to launch.
 
 ---
 

--- a/server/state_manager.py
+++ b/server/state_manager.py
@@ -34,9 +34,14 @@ class StateManager:
                 "Missing required environment variable: TOKEN_ENCRYPTION_KEY"
             )
         try:
-            self._encryption_key = base64.b64decode(key_b64)
+            key_bytes = base64.b64decode(key_b64)
         except Exception as exc:  # pragma: no cover - invalid base64 rare
             raise ConfigError("Invalid TOKEN_ENCRYPTION_KEY format") from exc
+        if len(key_bytes) != 16:
+            raise ConfigError(
+                "TOKEN_ENCRYPTION_KEY must decode to 16 bytes (128-bit AES key)"
+            )
+        self._encryption_key = key_bytes
 
     def _key(self, call_sid: str) -> str:
         return f"{self.prefix}:{call_sid}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,3 +158,9 @@ def test_create_app_missing_token_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("TOKEN_ENCRYPTION_KEY", raising=False)
     with pytest.raises(RuntimeError):
         create_app()
+
+
+def test_create_app_invalid_token_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"abc").decode())
+    with pytest.raises(RuntimeError):
+        create_app()

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -62,3 +62,10 @@ def test_missing_encryption_key(monkeypatch: Any, tmp_path: Path) -> None:
     monkeypatch.setenv("VECTOR_DB_PATH", str(tmp_path / "vectors"))
     with pytest.raises(ConfigError):
         StateManager(url="redis://localhost:6379/0")
+
+
+def test_invalid_encryption_key_length(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"short").decode())
+    monkeypatch.setenv("VECTOR_DB_PATH", str(tmp_path / "vectors"))
+    with pytest.raises(ConfigError):
+        StateManager(url="redis://localhost:6379/0")


### PR DESCRIPTION
### Task
- ID: 47 – CORE-47

### Description
- enforce that TOKEN_ENCRYPTION_KEY is provided and is 128-bit
- document key generation and storage
- add tests for missing/invalid key

### Checklist
- [x] Tests added
- [x] Docs updated
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686dad4d1a48832abd6a6cb95ca43a78