### PR TITLE
CI-03 run pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: pip install -r requirements.txt
+      - name: Install git-secrets
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-secrets
+          git secrets --install -f
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit


### PR DESCRIPTION
### Task
- ID: 50 – CI-03

### Description
- Run `pre-commit run --all-files` in CI before executing tests.
- Install `git-secrets` so the local hook can run.

### Checklist
- [x] Tests pass
- [x] Hooks (black, ruff, git-secrets) pass
- [x] CI updated

------
https://chatgpt.com/codex/tasks/task_e_686db6ce843c832a83ad409dd8bf5c98