### PR TITLE
CORE-17 enforce persistent token key

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,16 @@ EOF
 
 Add the resulting value to your `.env` file under `TOKEN_ENCRYPTION_KEY` before
 starting the server. The decoded key must be exactly 16 bytes (AES‑128).
+Example:
+
+```bash
+TOKEN_ENCRYPTION_KEY="$(python - <<'EOF'
+import base64, os
+print(base64.b64encode(os.urandom(16)).decode())
+EOF
+)"
+```
+
 Without this key, TEL3SIS will refuse to launch.
 
 ---

--- a/server/state_manager.py
+++ b/server/state_manager.py
@@ -28,6 +28,10 @@ class StateManager:
 
         self._summary_db = summary_db or VectorDB(collection_name="summaries")
 
+        self._encryption_key = self._load_encryption_key()
+
+    def _load_encryption_key(self) -> bytes:
+        """Return the AES key from ``TOKEN_ENCRYPTION_KEY`` env variable."""
         key_b64 = os.getenv("TOKEN_ENCRYPTION_KEY")
         if not key_b64:
             raise ConfigError(
@@ -41,7 +45,7 @@ class StateManager:
             raise ConfigError(
                 "TOKEN_ENCRYPTION_KEY must decode to 16 bytes (128-bit AES key)"
             )
-        self._encryption_key = key_bytes
+        return key_bytes
 
     def _key(self, call_sid: str) -> str:
         return f"{self.prefix}:{call_sid}"

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,0 +1,14 @@
+import pytest
+
+from server.app import create_app
+
+
+def test_server_fails_without_token_key(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "x")
+    monkeypatch.setenv("BASE_URL", "http://localhost")
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.delenv("TOKEN_ENCRYPTION_KEY", raising=False)
+
+    with pytest.raises(RuntimeError):
+        create_app()


### PR DESCRIPTION
### Task
- ID: 47 – CORE-17

### Description
- raise an explicit error if `TOKEN_ENCRYPTION_KEY` is missing
- document generation and storage steps in README
- add regression test for startup without the key

### Checklist
- [x] Tests added
- [x] Docs updated
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686dbd84306c832a88375eef22a29423