### PR TITLE
API-02: require API keys

### DIFF
--- a/tests/test_calls_blueprint.py
+++ b/tests/test_calls_blueprint.py
@@ -148,11 +148,12 @@ def test_list_calls(monkeypatch, tmp_path):
     reload(db)
     db.init_db()
     db.save_call_summary("abc", "111", "222", "/path", "summary", "crit")
+    key = db.create_api_key("tester")
 
     app = create_app()
     client = app.test_client()
 
-    resp = client.get("/v1/calls")
+    resp = client.get("/v1/calls", headers={"X-API-Key": key})
     assert resp.status_code == 200
     data = resp.get_json()
     assert data[0]["call_sid"] == "abc"


### PR DESCRIPTION
### Task
- ID: 57 – API-02

### Description
Implements API key authentication for all `/v1` endpoints. A new `APIKey` model stores hashed keys and owners. Each request under `/v1/` must include an `X-API-Key` header, validated against stored hashes. Unit tests exercise missing, invalid and valid key scenarios.

### Checklist
- [x] Tests added
- [x] Docs updated
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686dd00e4218832aa5f76156f59e518b