### PR TITLE
Resolve pytest import error from agent file

### DIFF
--- a/agents/test_crafter.py
+++ b/agents/test_crafter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__test__ = False
+
 from dataclasses import dataclass
 from typing import Optional
 import os


### PR DESCRIPTION
### Task
- ID: none

### Description
- Prevent `agents/test_crafter.py` from being treated as a pytest file by setting `__test__ = False`.
- Verified `pytest --collect-only` runs without import errors.

### Checklist
- [x] Tests pass
- [x] CI commands (lint, tests, pre-commit) pass


------
https://chatgpt.com/codex/tasks/task_e_686de3f15eb0832a8361e5ac1b447a0f