### PR TITLE
Add async Flask routes

### DIFF
--- a/tests/test_async_calls.py
+++ b/tests/test_async_calls.py
@@ -1,0 +1,80 @@
+import base64
+import types
+from importlib import reload
+
+
+# Reuse dummy vocode modules from test_api_key_auth
+import tests.test_api_key_auth  # noqa: F401
+
+from server import database as db
+
+
+def test_async_inbound_call(monkeypatch, tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("SECRET_KEY", "x")
+    monkeypatch.setenv("BASE_URL", "http://localhost")
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
+    reload(db)
+    db.init_db()
+    key = db.create_api_key("tester")
+
+    from server import app as server_app
+    from server.app import create_app
+
+    class DummyStateManager:
+        def create_session(self, *a, **k):
+            pass
+
+        def is_escalation_required(self, *_: object) -> bool:
+            return False
+
+        def get_summary(self, *_: object) -> str:
+            return ""
+
+    monkeypatch.setattr(server_app, "StateManager", lambda: DummyStateManager())
+
+    monkeypatch.setattr(
+        server_app,
+        "build_core_agent",
+        lambda *_, **__: types.SimpleNamespace(agent=None),
+    )
+    monkeypatch.setattr(
+        server_app, "echo", types.SimpleNamespace(delay=lambda *_, **__: None)
+    )
+
+    app = create_app()
+    client = app.test_client()
+    resp = client.post(
+        "/v1/inbound_call",
+        data={"CallSid": "CA1", "From": "+12025550100", "To": "+12025550101"},
+        headers={"X-API-Key": key},
+    )
+    assert resp.status_code == 200
+
+
+def test_async_recording_status(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "x")
+    monkeypatch.setenv("BASE_URL", "http://localhost")
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
+    from server import app as server_app
+    from server.app import create_app
+
+    monkeypatch.setattr(server_app, "verify_api_key", lambda *_: True)
+
+    app = create_app()
+    client = app.test_client()
+    resp = client.post(
+        "/v1/recording_status",
+        data={
+            "CallSid": "CA1",
+            "RecordingSid": "RS1",
+            "RecordingUrl": "http://example.com",
+        },
+        headers={"X-API-Key": "dummy"},
+    )
+    assert resp.status_code == 204


### PR DESCRIPTION
### Task
- ID: 63 – ARCH-01

### Description
- switched Twilio webhook handlers to async functions
- added integration test covering async endpoints

### Checklist
- [x] Tests added
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686df5c64b8c832abb97b0b929a39ffc