### PR TITLE
Add FastAPI async server and concurrency test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,6 @@ prometheus_client==0.19.0
 pydantic==2.7.1
 langdetect==1.0.9
 sentence-transformers==2.7.0
+fastapi==0.111.0
+httpx==0.27.0
+python-multipart==0.0.9

--- a/server/fast_app.py
+++ b/server/fast_app.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import os
+
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, ValidationError, HttpUrl
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from loguru import logger
+
+from vocode.streaming.telephony.server.base import (
+    TelephonyServer,
+    TwilioInboundCallConfig,
+)
+from vocode.streaming.telephony.config_manager.in_memory_config_manager import (
+    InMemoryConfigManager,
+)
+from vocode.streaming.models.telephony import TwilioConfig
+
+from .database import (
+    init_db,
+    get_user_preference,
+    set_user_preference,
+    verify_api_key,
+)
+from .config import Config, ConfigError
+from .handoff import dial_twiml
+from .state_manager import StateManager
+from .tasks import echo
+from tools.notifications import send_sms
+from tools.calendar import generate_auth_url, exchange_code
+from agents.core_agent import build_core_agent, SafeAgentFactory
+from .validation import validation_error_response
+
+
+class InboundCallData(BaseModel):
+    CallSid: str
+    From: str
+    To: str
+
+
+class RecordingStatusData(BaseModel):
+    CallSid: str
+    RecordingSid: str
+    RecordingUrl: HttpUrl
+
+
+class OAuthStartData(BaseModel):
+    user_id: str | None = None
+
+
+class OAuthCallbackData(BaseModel):
+    state: str
+    user: str | None = None
+
+
+def create_app() -> FastAPI:
+    try:
+        config = Config()
+    except ConfigError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+    app = FastAPI()
+
+    init_db()
+
+    base_url = config.base_url
+    twilio_config = TwilioConfig(
+        account_sid=config.twilio_account_sid,
+        auth_token=config.twilio_auth_token,
+        record=True,
+    )
+
+    telephony_server = TelephonyServer(
+        base_url=base_url,
+        config_manager=InMemoryConfigManager(),
+        agent_factory=SafeAgentFactory(),
+    )
+
+    try:
+        state_manager = StateManager()
+    except ConfigError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+    @app.middleware("http")
+    async def require_api_key(request: Request, call_next):
+        if request.url.path.startswith("/v1/"):
+            key = request.headers.get("X-API-Key")
+            if not key or not verify_api_key(key):
+                return Response("Unauthorized", status_code=401)
+        return await call_next(request)
+
+    @app.get("/v1/oauth/start")
+    async def oauth_start(request: Request):
+        try:
+            data = OAuthStartData(**request.query_params)
+        except ValidationError as exc:
+            return validation_error_response(exc)
+        url = generate_auth_url(state_manager, data.user_id or "")
+        return RedirectResponse(url)
+
+    @app.get("/v1/oauth/callback")
+    async def oauth_callback(request: Request):
+        try:
+            data = OAuthCallbackData(**request.query_params)
+        except ValidationError as exc:
+            return validation_error_response(exc)
+        exchange_code(state_manager, data.state, str(request.url))
+        return "Authentication successful"
+
+    @app.post("/v1/inbound_call")
+    async def inbound_call(request: Request):
+        try:
+            form = await request.form()
+            data = InboundCallData(**form)
+        except ValidationError as exc:
+            return validation_error_response(exc)
+
+        call_sid = data.CallSid
+        state_manager.create_session(
+            call_sid,
+            {"from": data.From, "to": data.To},
+        )
+        echo.delay(f"Call {call_sid} started")
+
+        language = get_user_preference(data.From, "language")
+        if not language:
+            from tools.language import guess_language_from_number
+
+            language = guess_language_from_number(data.From)
+            set_user_preference(data.From, "language", language)
+        if hasattr(state_manager, "update_session"):
+            state_manager.update_session(call_sid, language=language)
+
+        config_obj = build_core_agent(state_manager, call_sid, language=language)
+        inbound_route = telephony_server.create_inbound_route(
+            TwilioInboundCallConfig(
+                url="/v1/inbound_call",
+                agent_config=config_obj.agent,
+                twilio_config=twilio_config,
+            )
+        )
+
+        async def escalate():
+            summary = state_manager.get_summary(call_sid) or ""
+            send_sms(
+                to_phone=os.environ.get("ESCALATION_PHONE_NUMBER", ""),
+                from_phone=data.From,
+                body=summary,
+            )
+            xml = dial_twiml(data.From)
+            return Response(content=xml, media_type="text/xml")
+
+        if state_manager.is_escalation_required(call_sid):
+            return await escalate()
+
+        response = await inbound_route(
+            twilio_sid=data.CallSid,
+            twilio_from=data.From,
+            twilio_to=data.To,
+        )
+
+        if state_manager.is_escalation_required(call_sid):
+            return await escalate()
+
+        return Response(
+            content=response.body,
+            status_code=response.status_code,
+            media_type=response.media_type,
+        )
+
+    @app.post("/v1/recording_status")
+    async def recording_status(request: Request):
+        try:
+            form = await request.form()
+            data = RecordingStatusData(**form)
+        except ValidationError as exc:
+            return validation_error_response(exc)
+
+        logger.info(
+            "Recording callback: call_sid=%s recording_sid=%s url=%s",
+            data.CallSid,
+            data.RecordingSid,
+            data.RecordingUrl,
+        )
+        return Response(status_code=204)
+
+    @app.get("/v1/metrics")
+    async def metrics():
+        return Response(
+            content=generate_latest(),
+            media_type=CONTENT_TYPE_LATEST,
+        )
+
+    return app

--- a/tests/test_concurrent_calls.py
+++ b/tests/test_concurrent_calls.py
@@ -1,0 +1,84 @@
+import asyncio
+import base64
+import types
+from importlib import reload
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import httpx
+import tests.test_api_key_auth  # noqa: F401
+from server import database as db
+from server import fast_app as server_app
+
+
+def test_concurrent_inbound_calls(monkeypatch, tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("SECRET_KEY", "x")
+    monkeypatch.setenv("BASE_URL", "http://localhost")
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
+    reload(db)
+    db.init_db()
+    key = db.create_api_key("tester")
+
+    class DummyStateManager:
+        def create_session(self, *a, **k):
+            pass
+
+        def is_escalation_required(self, *_: object) -> bool:
+            return False
+
+        def get_summary(self, *_: object) -> str:
+            return ""
+
+    monkeypatch.setattr(server_app, "StateManager", lambda: DummyStateManager())
+
+    async def delayed_route(**_: object):
+        await asyncio.sleep(0.2)
+        return types.SimpleNamespace(body=b"", status_code=200, media_type="text/plain")
+
+    class DummyServer:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        def create_inbound_route(self, *_: object, **__: object):
+            return delayed_route
+
+    monkeypatch.setattr(server_app, "TelephonyServer", DummyServer)
+    monkeypatch.setattr(
+        server_app,
+        "build_core_agent",
+        lambda *_, **__: types.SimpleNamespace(agent=None),
+    )
+    monkeypatch.setattr(
+        server_app, "echo", types.SimpleNamespace(delay=lambda *_, **__: None)
+    )
+
+    app = server_app.create_app()
+
+    async def run_test() -> float:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+
+            async def make_call(i: int) -> None:
+                resp = await client.post(
+                    "/v1/inbound_call",
+                    data={
+                        "CallSid": f"CA{i}",
+                        "From": "+12025550000",
+                        "To": "+12025550001",
+                    },
+                    headers={"X-API-Key": key},
+                )
+                assert resp.status_code == 200
+
+            await asyncio.gather(*(make_call(i) for i in range(3)))
+        return None
+
+    asyncio.run(run_test())


### PR DESCRIPTION
### Task
- Implement asynchronous FastAPI app for telephony endpoints
- Add python-multipart requirement
- Include test simulating concurrent inbound calls

### Checklist
- [x] Tests added
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686e07294660832a989db9e0f66fb099