### PR TITLE
Implement live transcript streaming

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ cryptography==44.0.1
 Flask==3.0.2
 Flask-Login==0.6.3
 Flask-Limiter==3.5.0
+Flask-SocketIO==5.3.6
 oauthlib==3.2.2
 
 # Speech-to-text

--- a/server/state_manager.py
+++ b/server/state_manager.py
@@ -161,6 +161,12 @@ class StateManager:
             history = []
         history.append({"speaker": speaker, "text": text})
         self._redis.hset(key, "history", json.dumps(history))
+        try:
+            from .dashboard_bp import stream_transcript_line
+
+            stream_transcript_line(call_sid, speaker, text)
+        except Exception:  # pragma: no cover - socket may not be configured
+            pass
 
     def get_history(self, call_sid: str) -> List[Dict[str, str]]:
         """Return conversation history for a call."""

--- a/server/templates/dashboard/detail.html
+++ b/server/templates/dashboard/detail.html
@@ -7,5 +7,17 @@
 <p>Self Critique: {{ call.self_critique }}</p>
 {% endif %}
 <audio controls src="{{ audio_path }}"></audio>
-<pre>{{ transcript }}</pre>
+<pre id="transcript">{{ transcript }}</pre>
+<script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+<script>
+  const socket = io();
+  socket.emit('join', {call_sid: '{{ call.call_sid }}'});
+  socket.on('transcript_line', (data) => {
+    const pre = document.getElementById('transcript');
+    pre.textContent += '\n' + data.speaker + ': ' + data.text;
+  });
+  window.addEventListener('beforeunload', () => {
+    socket.emit('leave', {call_sid: '{{ call.call_sid }}'});
+  });
+</script>
 <p><a href="{{ url_for('dashboard.show_dashboard') }}">Back</a></p>

--- a/tests/test_live_transcript.py
+++ b/tests/test_live_transcript.py
@@ -1,0 +1,43 @@
+import base64
+import sys
+from pathlib import Path
+
+import fakeredis
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from flask import Flask
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from server.state_manager import StateManager
+from server.dashboard_bp import bp, socketio
+
+
+def _make_manager(monkeypatch):
+    key = AESGCM.generate_key(bit_length=128)
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(key).decode())
+    monkeypatch.setenv("VECTOR_DB_PATH", "vectors")
+    manager = StateManager(url="redis://localhost:6379/0")
+    manager._redis = fakeredis.FakeRedis(decode_responses=True)
+    return manager
+
+
+def _make_app():
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "x"
+    app.register_blueprint(bp)
+    socketio.init_app(app, async_mode="threading")
+    return app
+
+
+def test_streaming(monkeypatch):
+    manager = _make_manager(monkeypatch)
+    app = _make_app()
+    client = socketio.test_client(app)
+    client.emit("join", {"call_sid": "c1"})
+    manager.create_session("c1", {"init": "1"})
+    manager.append_history("c1", "user", "hello")
+    received = client.get_received()
+    assert received
+    evt = received[0]
+    assert evt["name"] == "transcript_line"
+    assert evt["args"][0]["text"] == "hello"


### PR DESCRIPTION
### Task
- Extend `dashboard_bp.py` with Flask-SocketIO to stream call transcripts

### Description
- added `Flask-SocketIO` dependency
- created socket endpoints and streaming helper
- broadcast transcript updates from `StateManager`
- updated dashboard template with JS client
- added regression test for streaming behaviour

### Checklist
- [x] Tests added
- [x] Docs updated
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_e_686e4f8718f8832ab7bd07e2965385e4