### PR TITLE
Add concurrency performance test

### DIFF
--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,97 @@
+import asyncio
+import base64
+import sys
+import time
+import types
+from importlib import reload
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import httpx
+import pytest
+
+import tests.test_api_key_auth  # noqa: F401
+from server import database as db
+from server import fast_app as server_app
+
+
+def test_concurrent_call_performance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("SECRET_KEY", "x")
+    monkeypatch.setenv("BASE_URL", "http://localhost")
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
+    reload(db)
+    db.init_db()
+    key = db.create_api_key("tester")
+
+    class DummyStateManager:
+        def create_session(self, *a: object, **k: object) -> None:  # pragma: no cover
+            pass
+
+        def is_escalation_required(self, *_: object) -> bool:
+            return False
+
+        def get_summary(self, *_: object) -> str:
+            return ""
+
+    monkeypatch.setattr(server_app, "StateManager", lambda: DummyStateManager())
+
+    async def delayed_route(**_: object):
+        await asyncio.sleep(0.2)
+        return types.SimpleNamespace(body=b"", status_code=200, media_type="text/plain")
+
+    class DummyServer:
+        def __init__(self, *_: object, **__: object) -> None:  # pragma: no cover
+            pass
+
+        def create_inbound_route(self, *_: object, **__: object):
+            return delayed_route
+
+    monkeypatch.setattr(server_app, "TelephonyServer", DummyServer)
+    monkeypatch.setattr(
+        server_app,
+        "build_core_agent",
+        lambda *_, **__: types.SimpleNamespace(agent=None),
+    )
+    monkeypatch.setattr(
+        server_app, "echo", types.SimpleNamespace(delay=lambda *_, **__: None)
+    )
+
+    app = server_app.create_app()
+
+    async def run_test() -> tuple[float, float]:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+
+            async def make_call(i: int) -> None:
+                resp = await client.post(
+                    "/v1/inbound_call",
+                    data={
+                        "CallSid": f"CA{i}",
+                        "From": "+12025550000",
+                        "To": "+12025550001",
+                    },
+                    headers={"X-API-Key": key},
+                )
+                assert resp.status_code == 200
+
+            start = time.perf_counter()
+            for i in range(3):
+                await make_call(i)
+            sequential = time.perf_counter() - start
+
+            start = time.perf_counter()
+            await asyncio.gather(*(make_call(i) for i in range(3, 6)))
+            concurrent = time.perf_counter() - start
+
+            return sequential, concurrent
+
+    sequential, concurrent = asyncio.run(run_test())
+    assert concurrent < sequential


### PR DESCRIPTION
### Task
- ID: N/A
### Description
Add `tests/test_concurrency.py` that measures async call performance by comparing sequential and concurrent inbound calls.
### Checklist
- [x] Tests added
- [ ] Docs updated
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686e5f6ade1c832a98e0690b78e75da6