### PR TITLE
feat(ui): add theme toggle and dark mode

### DIFF
--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+<head>
+    <title>{% block title %}{% endblock %}</title>
+    <style>
+        body[data-theme="light"] {
+            background: #ffffff;
+            color: #000000;
+        }
+        body[data-theme="dark"] {
+            background: #1e1e1e;
+            color: #eeeeee;
+        }
+        .theme-toggle {
+            position: fixed;
+            top: 1rem;
+            right: 1rem;
+        }
+    </style>
+    {% block head %}{% endblock %}
+</head>
+<body data-theme="{{ request.cookies.get('theme', 'light') }}">
+{% block toggle %}{% endblock %}
+{% block content %}{% endblock %}
+<script>
+function setCookie(name, value) {
+  document.cookie = name + '=' + value + '; path=/';
+}
+function getCookie(name) {
+  const m = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
+  return m ? m[2] : null;
+}
+function applyTheme(theme) {
+  document.body.dataset.theme = theme;
+}
+function toggleTheme() {
+  const current = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+  applyTheme(current);
+  setCookie('theme', current);
+}
+document.addEventListener('DOMContentLoaded', () => {
+  const saved = getCookie('theme');
+  if (saved) applyTheme(saved);
+});
+</script>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/server/templates/dashboard/detail.html
+++ b/server/templates/dashboard/detail.html
@@ -1,5 +1,6 @@
-<!doctype html>
-<title>Call Detail</title>
+{% extends "dashboard/layout.html" %}
+{% block title %}Call Detail{% endblock %}
+{% block content %}
 <h1>Call {{ call.call_sid }}</h1>
 <p>From: {{ call.from_number }} → {{ call.to_number }}</p>
 <p>Summary: {{ call.summary }}</p>
@@ -21,3 +22,4 @@
   });
 </script>
 <p><a href="{{ url_for('dashboard.show_dashboard') }}">Back</a></p>
+{% endblock %}

--- a/server/templates/dashboard/layout.html
+++ b/server/templates/dashboard/layout.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+{% block toggle %}
+<button class="theme-toggle" onclick="toggleTheme()">Toggle theme</button>
+{% endblock %}

--- a/server/templates/dashboard/list.html
+++ b/server/templates/dashboard/list.html
@@ -1,5 +1,6 @@
-<!doctype html>
-<title>Call Dashboard</title>
+{% extends "dashboard/layout.html" %}
+{% block title %}Call Dashboard{% endblock %}
+{% block content %}
 <h1>Call History</h1>
 <form method="get">
   <input type="text" name="q" placeholder="Search" value="{{ q }}" />
@@ -16,3 +17,4 @@
   <li>No calls found.</li>
 {% endfor %}
 </ul>
+{% endblock %}

--- a/server/templates/login.html
+++ b/server/templates/login.html
@@ -1,8 +1,10 @@
-<!doctype html>
-<title>Login</title>
+{% extends "base.html" %}
+{% block title %}Login{% endblock %}
+{% block content %}
 {% if error %}<p>{{ error }}</p>{% endif %}
 <form method="post">
   <input type="text" name="username" placeholder="Username" />
   <input type="password" name="password" placeholder="Password" />
   <button type="submit">Login</button>
 </form>
+{% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -3,6 +3,9 @@ import sys
 import os
 import base64
 from importlib import reload
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 # Provide dummy "vocode" modules so that server.app can be imported without the real dependency.
 dummy = types.ModuleType("vocode")
@@ -98,24 +101,24 @@ dummy.streaming.models.telephony.TwilioConfig = TwilioConfig
 sys.modules["vocode"] = dummy
 sys.modules["vocode.streaming"] = dummy.streaming
 sys.modules["vocode.streaming.agent"] = dummy.streaming.agent
-sys.modules[
-    "vocode.streaming.agent.chat_gpt_agent"
-] = dummy.streaming.agent.chat_gpt_agent
+sys.modules["vocode.streaming.agent.chat_gpt_agent"] = (
+    dummy.streaming.agent.chat_gpt_agent
+)
 sys.modules["vocode.streaming.agent.base_agent"] = dummy.streaming.agent.base_agent
-sys.modules[
-    "vocode.streaming.agent.default_factory"
-] = dummy.streaming.agent.default_factory
+sys.modules["vocode.streaming.agent.default_factory"] = (
+    dummy.streaming.agent.default_factory
+)
 sys.modules["vocode.streaming.telephony"] = dummy.streaming.telephony
 sys.modules["vocode.streaming.telephony.server"] = dummy.streaming.telephony.server
-sys.modules[
-    "vocode.streaming.telephony.server.base"
-] = dummy.streaming.telephony.server.base
-sys.modules[
-    "vocode.streaming.telephony.config_manager"
-] = dummy.streaming.telephony.config_manager
-sys.modules[
-    "vocode.streaming.telephony.config_manager.in_memory_config_manager"
-] = dummy.streaming.telephony.config_manager.in_memory_config_manager
+sys.modules["vocode.streaming.telephony.server.base"] = (
+    dummy.streaming.telephony.server.base
+)
+sys.modules["vocode.streaming.telephony.config_manager"] = (
+    dummy.streaming.telephony.config_manager
+)
+sys.modules["vocode.streaming.telephony.config_manager.in_memory_config_manager"] = (
+    dummy.streaming.telephony.config_manager.in_memory_config_manager
+)
 sys.modules["vocode.streaming.models"] = dummy.streaming.models
 sys.modules["vocode.streaming.models.agent"] = dummy.streaming.models.agent
 sys.modules["vocode.streaming.models.actions"] = dummy.streaming.models.actions
@@ -203,3 +206,17 @@ def test_oauth_callback_validation(monkeypatch) -> None:
     resp = client.get("/v1/oauth/callback", headers={"X-API-Key": key})
     assert resp.status_code == 400
     assert resp.json()["error"] == "invalid_request"
+
+
+def test_dashboard_theme_toggle_template() -> None:
+    """Ensure dashboard template includes theme toggle button."""
+    from flask import Flask, render_template
+    from server.dashboard_bp import bp as dashboard_bp
+
+    app = Flask(__name__)
+    app.register_blueprint(dashboard_bp)
+
+    with app.test_request_context("/v1/dashboard", headers={"Cookie": "theme=dark"}):
+        html = render_template("dashboard/list.html", calls=[], q="")
+
+    assert '<button class="theme-toggle"' in html


### PR DESCRIPTION
### Task
- ID: N/A – UI update
### Description
Adds light/dark theme support with a cookie-based toggle in dashboard templates.
### Checklist
- [x] Tests added
- [ ] Docs updated
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686e83a7e6e4832a95f04bb223aae609