### PR TITLE
Add periodic token refresh

### DIFF
--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -23,6 +23,10 @@ def create_celery_app() -> Celery:
             "task": "server.tasks.backup_data",
             "schedule": crontab(minute=0, hour=1),
         },
+        "refresh-tokens": {
+            "task": "server.tasks.refresh_tokens_task",
+            "schedule": crontab(minute="*/10"),
+        },
     }
     return celery
 


### PR DESCRIPTION
### Task
- ID: N/A
- Adds scheduled Celery job to refresh expiring tokens

### Description
- Added `refresh_tokens_task` to check OAuth tokens in `StateManager` and refresh those nearing expiry.
- Registered new task in `celery_app` beat schedule.
- Added `iter_tokens` helper to `StateManager` for scanning stored tokens.
- Expanded calendar tests to exercise refresh logic and adjusted auth failure test to use patched `StateManager`.

### Checklist
- [x] Tests added
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686e8d184f28832a98b3e6e320a3f138