### PR TITLE
Add maintenance CLI utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,20 @@ python scripts/manage.py generate-api-key alice
 python scripts/manage.py cleanup --days 30
 ```
 
+### Maintenance Commands
+
+These utilities provide quick access to call history and cleanup tasks. After
+installing the package with `pip install -e .`, invoke them via the console
+script or directly with Python:
+
+```bash
+# list recent calls
+tel3sis-maintenance list-calls
+
+# prune calls older than 90 days
+tel3sis-maintenance prune --days 90
+```
+
 ---
 
 ## 📊 Monitoring

--- a/scripts/maintenance.py
+++ b/scripts/maintenance.py
@@ -1,0 +1,38 @@
+import click
+
+from server import tasks
+from server.database import Call, get_session
+
+
+@click.group(help="Maintenance utilities for TEL3SIS")
+def cli() -> None:
+    """Entry point for maintenance CLI."""
+    pass
+
+
+@cli.command("list-calls")
+def list_calls_cmd() -> None:
+    """Print all stored call records."""
+    with get_session() as session:
+        calls = session.query(Call).order_by(Call.created_at.desc()).all()
+        for call in calls:
+            click.echo(
+                f"{call.id}: {call.call_sid} {call.from_number} -> {call.to_number} @ {call.created_at.isoformat()}"
+            )
+
+
+@cli.command("prune")
+@click.option(
+    "--days",
+    default=30,
+    show_default=True,
+    help="Remove calls older than DAYS days",
+)
+def prune_cmd(days: int) -> None:
+    """Delete call records older than ``days`` days."""
+    removed = tasks.cleanup_old_calls.run(days=days)
+    click.echo(f"Removed {removed} calls older than {days} days.")
+
+
+if __name__ == "__main__":
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="tel3sis",
+    version="0.1.0",
+    packages=find_packages(),
+    entry_points={
+        "console_scripts": [
+            "tel3sis-manage=scripts.manage:cli",
+            "tel3sis-maintenance=scripts.maintenance:cli",
+        ]
+    },
+)


### PR DESCRIPTION
### Task
- ID: N/A

### Description
- introduce `scripts/maintenance.py` with `list-calls` and `prune`
- expose new command via `setup.py` console entry point
- document usage under new **Maintenance Commands** section in README

### Checklist
- [x] Tests added N/A
- [x] Docs updated
- [x] CI green

------
https://chatgpt.com/codex/tasks/task_e_686e9df15774832a94443612c8bd1c78