### PR TITLE
Add migrate command to manage.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ pytest -q
 ```bash
 python scripts/manage.py create-user alice secret --role admin
 python scripts/manage.py generate-api-key alice
+python scripts/manage.py migrate
 python scripts/manage.py cleanup --days 30
 ```
 

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -4,7 +4,7 @@ This document describes the HTTP endpoints under `/v1` exposed by the TEL3SIS se
 
 ## Authentication
 
-Generate an API key using `tel3sis-manage generate-api-key <owner>` and include it in the `X-API-Key` header:
+Generate an API key using `tel3sis-manage generate-api-key <owner>` and include it in the `X-API-Key` header. Initialize the database with `tel3sis-manage migrate`:
 
 ```bash
 X-API-Key: YOUR_API_KEY

--- a/docs/index.md
+++ b/docs/index.md
@@ -227,6 +227,7 @@ pytest -q
 ```bash
 python scripts/manage.py create-user alice secret --role admin
 python scripts/manage.py generate-api-key alice
+python scripts/manage.py migrate
 python scripts/manage.py cleanup --days 30
 ```
 

--- a/scripts/manage.py
+++ b/scripts/manage.py
@@ -1,4 +1,6 @@
 import click
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
 
 from server import database as db
 from server import tasks
@@ -27,6 +29,14 @@ def generate_api_key_cmd(owner: str) -> None:
     db.init_db()
     key = db.create_api_key(owner)
     click.echo(key)
+
+
+@cli.command()
+def migrate() -> None:
+    """Apply database migrations."""
+    alembic_cfg = AlembicConfig("alembic.ini")
+    alembic_command.upgrade(alembic_cfg, "head")
+    click.echo("Database migrated to head.")
 
 
 @cli.command()


### PR DESCRIPTION
### Summary
- support alembic migrations via `scripts/manage.py migrate`
- document the new command in README and docs
- mention migration setup in API usage docs

### Testing
- `pre-commit run --files scripts/manage.py docs/index.md README.md docs/api_usage.md`
- `pytest -q --maxfail=1 --lf` *(fails: KeyboardInterrupt after 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686f6c521344832a9faa00525af0535a