### PR TITLE
CI-04: add caching for pip and Docker layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install ruff
         run: pip install ruff
       - name: Run ruff
@@ -24,6 +30,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
       - name: Install git-secrets
@@ -51,5 +63,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Docker build
-        run: docker build --target runtime -t tel3sis .
+      - uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: runtime
+          load: true
+          tags: tel3sis:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/tasks.yml
+++ b/tasks.yml
@@ -1323,7 +1323,7 @@ tasks:
     area: CI/CD
     dependencies: [38]
     priority: 3
-    status: pending
+    status: done
     assigned_to: null
     command: null
     actionable_steps:


### PR DESCRIPTION
### Task
- ID: 71 – CI-04

### Description
Implement caching in `ci.yml` for pip downloads and Docker build layers. Pip cache uses `actions/cache` on `~/.cache/pip`; Docker build now uses `docker/setup-buildx-action` and `docker/build-push-action` with `gha` cache. Updated `tasks.yml` to mark the task done.

### Checklist
- [x] Tests run *(fail: numpy deprecation)*
- [x] `pre-commit` ran
- [ ] CI logs confirm cache reuse *(API access failed)*

------
https://chatgpt.com/codex/tasks/task_e_686fb69b1408832ab0c26a4174303a23