### PR TITLE
Add Compose health workflow

### DIFF
--- a/.github/workflows/compose_test.yml
+++ b/.github/workflows/compose_test.yml
@@ -1,0 +1,34 @@
+name: Compose Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  compose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Start services
+        run: docker compose up -d
+      - name: Wait for health checks
+        run: |
+          sudo apt-get update && sudo apt-get install -y jq curl
+          for i in {1..30}; do
+            status=$(curl -s http://localhost:3000/v1/health || true)
+            echo "$status"
+            if echo "$status" | jq -e 'all(.[]=="ok")'; then
+              echo "All services healthy"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Services failed to become healthy" >&2
+          docker compose ps
+          docker compose logs
+          exit 1
+      - name: Stop services
+        if: always()
+        run: docker compose down
+

--- a/tasks.yml
+++ b/tasks.yml
@@ -1360,7 +1360,7 @@ tasks:
     area: Quality
     dependencies: [38]
     priority: 2
-    status: pending
+    status: in_review
     assigned_to: null
     command: null
     actionable_steps:


### PR DESCRIPTION
### Task
- ID: 73 – QA-04

### Description
Adds a GitHub Actions workflow that spins up the compose stack and waits for the health endpoint to report all services as `ok`. Updates task status accordingly.

### Checklist
- [ ] Tests added
- [ ] Docs updated
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_686fc1ea6d4c832aa214166f29ae8cb1