### PR TITLE
Add GHCR release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: runtime
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/tel3sis:${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create GitHub release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -304,6 +304,23 @@ We follow the **Conventional Commits** spec.
 
 ---
 
+## 🚀 Releases
+
+Tag a version using `v*` to build and publish the Docker image. Example:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The release workflow publishes `ghcr.io/<org>/tel3sis:<tag>`. Pull it with:
+
+```bash
+docker pull ghcr.io/<org>/tel3sis:v0.1.0
+```
+
+---
+
 ## 📜 License
 
 MIT. See `LICENSE`.

--- a/tasks.yml
+++ b/tasks.yml
@@ -1341,7 +1341,7 @@ tasks:
     area: CI/CD
     dependencies: [38, 70]
     priority: 3
-    status: pending
+    status: done
     assigned_to: null
     command: null
     actionable_steps:


### PR DESCRIPTION
### Task
- ID: 72 – CI-05

### Description
Implemented release automation for tagged versions. The new workflow builds the Docker image from the multi-stage Dockerfile, pushes it to GHCR and publishes a GitHub release. Docs now describe tagging and pulling images. Updated `tasks.yml` to mark the release workflow task as done.

### Checklist
- [x] Tests executed
- [x] Pre-commit hooks


------
https://chatgpt.com/codex/tasks/task_e_686fc56759b0832aa37a1f56cdc6332e