### PR TITLE
Add delete-user CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ pytest -q
 ```bash
 tel3sis manage create-user alice secret --role admin
 tel3sis manage generate-api-key alice
+tel3sis manage delete-user alice
 tel3sis manage migrate
 tel3sis manage cleanup --days 30
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -227,6 +227,7 @@ pytest -q
 ```bash
 tel3sis manage create-user alice secret --role admin
 tel3sis manage generate-api-key alice
+tel3sis manage delete-user alice
 tel3sis manage migrate
 tel3sis manage cleanup --days 30
 ```

--- a/scripts/manage.py
+++ b/scripts/manage.py
@@ -22,6 +22,17 @@ def create_user_cmd(username: str, password: str, role: str) -> None:
     click.echo(f"Created user '{username}' with role '{role}'.")
 
 
+@cli.command("delete-user")
+@click.argument("username")
+def delete_user_cmd(username: str) -> None:
+    """Delete a user account by ``username``."""
+    db.init_db()
+    if db.delete_user(username):
+        click.echo(f"Deleted user '{username}'.")
+    else:
+        click.echo(f"User '{username}' not found.")
+
+
 @cli.command("generate-api-key")
 @click.argument("owner")
 def generate_api_key_cmd(owner: str) -> None:

--- a/server/database.py
+++ b/server/database.py
@@ -179,3 +179,14 @@ def verify_api_key(key: str) -> bool:
             if check_password_hash(api_key.key_hash, key):
                 return True
     return False
+
+
+def delete_user(username: str) -> bool:
+    """Delete the user with ``username`` if it exists."""
+    with get_session() as session:
+        user = session.query(User).filter_by(username=username).one_or_none()
+        if user is None:
+            return False
+        session.delete(user)
+        session.commit()
+        return True

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -38,3 +38,18 @@ def test_cli_manage_api_key(monkeypatch):
     result = runner.invoke(cli, ["manage", "generate-api-key", "tester"])
     assert result.exit_code == 0
     assert "abc" in result.output
+
+
+def test_cli_manage_delete_user(monkeypatch):
+    calls = {}
+
+    monkeypatch.setattr("scripts.manage.db.init_db", lambda: None)
+    monkeypatch.setattr(
+        "scripts.manage.db.delete_user", lambda u: calls.setdefault("user", u) or True
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["manage", "delete-user", "bob"])
+
+    assert result.exit_code == 0
+    assert calls["user"] == "bob"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -31,3 +31,16 @@ def test_save_call_summary(tmp_path, monkeypatch):
         result = session.query(db.Call).filter_by(call_sid="abc").one()
         assert result.summary == "summary"
         assert result.self_critique == "crit"
+
+
+def test_create_and_delete_user(tmp_path, monkeypatch):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    db = migrate_sqlite(monkeypatch, tmp_path)
+    db.create_user("alice", "pw")
+    with db.get_session() as session:
+        assert session.query(db.User).filter_by(username="alice").count() == 1
+    assert db.delete_user("alice") is True
+    with db.get_session() as session:
+        assert session.query(db.User).filter_by(username="alice").count() == 0
+    assert db.delete_user("alice") is False


### PR DESCRIPTION
### Task
- ID: N/A

### Description
Implemented a `delete-user` subcommand for the `tel3sis manage` CLI. Added database helper to remove a user, updated documentation, and expanded tests for the new command.

### Checklist
- [x] Tests added
- [x] Docs updated
- [x] CI green

------
https://chatgpt.com/codex/tasks/task_e_68703e6e954c832abbb0ad81d5c407e6