### PR TITLE
docs: add instructions for pre-commit install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,17 @@ Thank you for helping improve **TEL3SIS**! Please follow the guidelines below to
    git secrets --scan -r
    ```
 
+### Installing `pre-commit`
+
+If you prefer to install `pre-commit` outside the bundled development
+requirements, grab it directly from PyPI and set up the git hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+
 ### Updating dependencies
 
 Runtime packages live in `requirements.in` and development tools in


### PR DESCRIPTION
### Summary
- document how to install pre-commit and run `pre-commit install`

### Testing
- `pre-commit run --files CONTRIBUTING.md`
- `black --check tel3sis`
- `ruff check tel3sis`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68704b8d67a8832abeca613a92febc27