### PR TITLE
Add user management enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ pytest -q
 
 ```bash
 tel3sis manage create-user alice secret --role admin
+tel3sis manage list-users
+tel3sis manage update-user alice --password newpass --role user
 tel3sis manage generate-api-key alice
 tel3sis manage delete-user alice
 tel3sis manage migrate

--- a/docs/index.md
+++ b/docs/index.md
@@ -226,6 +226,8 @@ pytest -q
 
 ```bash
 tel3sis manage create-user alice secret --role admin
+tel3sis manage list-users
+tel3sis manage update-user alice --password newpass --role user
 tel3sis manage generate-api-key alice
 tel3sis manage delete-user alice
 tel3sis manage migrate

--- a/scripts/manage.py
+++ b/scripts/manage.py
@@ -33,6 +33,28 @@ def delete_user_cmd(username: str) -> None:
         click.echo(f"User '{username}' not found.")
 
 
+@cli.command("list-users")
+def list_users_cmd() -> None:
+    """List all users in the system."""
+    db.init_db()
+    users = db.list_users()
+    for user in users:
+        click.echo(f"{user.id}: {user.username} ({user.role})")
+
+
+@cli.command("update-user")
+@click.argument("username")
+@click.option("--password", default=None, help="New password")
+@click.option("--role", default=None, help="New role")
+def update_user_cmd(username: str, password: str | None, role: str | None) -> None:
+    """Update user password and/or role."""
+    db.init_db()
+    if db.update_user(username, password=password, role=role):
+        click.echo(f"Updated user '{username}'.")
+    else:
+        click.echo(f"User '{username}' not found.")
+
+
 @cli.command("generate-api-key")
 @click.argument("owner")
 def generate_api_key_cmd(owner: str) -> None:

--- a/server/database.py
+++ b/server/database.py
@@ -190,3 +190,25 @@ def delete_user(username: str) -> bool:
         session.delete(user)
         session.commit()
         return True
+
+
+def list_users() -> list[User]:
+    """Return all users sorted by username."""
+    with get_session() as session:
+        return session.query(User).order_by(User.username).all()
+
+
+def update_user(
+    username: str, password: str | None = None, role: str | None = None
+) -> bool:
+    """Update user credentials and/or role. Return False if not found."""
+    with get_session() as session:
+        user = session.query(User).filter_by(username=username).one_or_none()
+        if user is None:
+            return False
+        if password is not None:
+            user.password_hash = generate_password_hash(password)
+        if role is not None:
+            user.role = role
+        session.commit()
+        return True

--- a/tasks.yml
+++ b/tasks.yml
@@ -1509,7 +1509,7 @@ tasks:
     area: DX
     dependencies: []
     priority: 4
-    status: in_progress
+    status: done
     assigned_to: null
     command: null
     actionable_steps:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -44,3 +44,18 @@ def test_create_and_delete_user(tmp_path, monkeypatch):
     with db.get_session() as session:
         assert session.query(db.User).filter_by(username="alice").count() == 0
     assert db.delete_user("alice") is False
+
+
+def test_list_and_update_user(tmp_path, monkeypatch):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    db = migrate_sqlite(monkeypatch, tmp_path)
+    db.create_user("alice", "pw", role="user")
+    db.create_user("bob", "pw", role="admin")
+
+    users = db.list_users()
+    assert [u.username for u in users] == ["alice", "bob"]
+
+    assert db.update_user("alice", password="new", role="admin") is True
+    updated = [u for u in db.list_users() if u.username == "alice"][0]
+    assert updated.role == "admin"


### PR DESCRIPTION
### Task
- ID: CLI-02

### Description
Implemented new `list-users` and `update-user` subcommands within the management CLI. Added corresponding helper functions in `server.database` and updated documentation. Extended tests to cover these new commands and database utilities. Updated `tasks.yml` to mark CLI-02 as done.

### Checklist
- [x] Tests added
- [x] Docs updated
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_e_6870557f4b30832abed686facb1e1762