### PR TITLE
DOC-07: production deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Detailed examples for every `/v1` endpoint can be found in [docs/api_usage.md](d
 
 ## 📚 Documentation
 For a deep dive into the system design, see the [core logic architecture review](docs/reviews/core_logic_architecture_review.md).
+Production deployment recommendations are covered in [docs/production.md](docs/production.md).
 
 ---
 **Local (non‑Docker) setup**  

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,0 +1,84 @@
+# Production Deployment Guide
+
+This guide outlines the recommended setup for running TEL3SIS in a
+production environment. It focuses on scaling Celery workers,
+keeping the database and message broker reliable, and shows example
+environment variables.
+
+## Celery Worker Pool
+
+Run multiple Celery worker instances to process tasks concurrently.
+Each worker can handle a configurable number of processes:
+
+```bash
+celery -A server.celery_app worker --concurrency=4 --loglevel=info
+```
+
+Scale horizontally by starting additional workers and consider using
+separate queues for long‑running jobs. Monitor the workload with
+`celery inspect` and adjust the number of workers as traffic grows.
+
+## Database Connection Pooling
+
+Use **PgBouncer** in front of PostgreSQL to handle many short‑lived
+connections created by Celery tasks and the FastAPI app.
+
+1. Run PgBouncer on the same network as your database.
+2. Point `DATABASE_URL` to the PgBouncer port, e.g.
+   `postgresql://user:pass@pgbouncer:6432/dbname`.
+3. Tune `default_pool_size` and `max_client_conn` based on expected
+   concurrency.
+
+PgBouncer minimizes connection overhead and keeps the database stable
+under load.
+
+## Redis High Availability
+
+TEL3SIS uses Redis for Celery and state management. For production,
+configure **Redis Sentinel** or **Redis Cluster** to avoid single
+points of failure.
+
+- **Redis Sentinel** provides automatic failover for a primary/replica
+  setup. Update `REDIS_URL`, `CELERY_BROKER_URL`, and
+  `CELERY_RESULT_BACKEND` to point to the Sentinel endpoints.
+- **Redis Cluster** shards data across multiple nodes. Use when you
+  require scaling beyond a single instance.
+
+Set the environment variables accordingly. Example using Sentinel:
+
+```bash
+REDIS_URL=redis://mymaster/0
+CELERY_BROKER_URL=redis://mymaster/0
+CELERY_RESULT_BACKEND=redis://mymaster/1
+```
+
+## Example Environment Settings
+
+A minimal `.env` for a production deployment might include:
+
+```bash
+BASE_URL=https://tel3sis.example.com
+DATABASE_URL=postgresql://user:pass@pgbouncer:6432/tel3sis
+REDIS_URL=redis://mymaster/0
+CELERY_BROKER_URL=${REDIS_URL}
+CELERY_RESULT_BACKEND=${REDIS_URL}
+CELERY_WORKER_CONCURRENCY=4
+```
+
+Override `CELERY_WORKER_CONCURRENCY` when starting each worker to scale
+up or down without changing the image.
+
+## Scaling Notes
+
+- Start with at least two Celery workers so that one can take over if
+the other stops. Increase the `--concurrency` value or add more
+workers as call volume rises.
+- PgBouncer reduces connection churn and allows the database to handle
+hundreds of worker processes efficiently.
+- Redis Sentinel or Cluster protects against broker outages. Always
+deploy at least three Sentinel nodes or six Cluster nodes for quorum.
+
+A typical production stack runs behind a load balancer (e.g. Nginx or
+a cloud ingress) with the above services on managed infrastructure.
+This architecture supports horizontal scaling as traffic demands.
+

--- a/tasks.yml
+++ b/tasks.yml
@@ -1454,7 +1454,7 @@ tasks:
     area: Ops
     dependencies: []
     priority: 3
-    status: pending
+    status: done
     assigned_to: null
     command: null
     actionable_steps:


### PR DESCRIPTION
### Task
- ID: 78 – DOC-07

### Description
Adds documentation for running TEL3SIS in production. The new guide covers scaling multiple Celery workers, using PgBouncer for database pooling, and configuring Redis Sentinel/Cluster. `README.md` now links to this guide and the task status is updated.

### Checklist
- [x] Tests executed
- [x] Docs updated
- [x] CI scripts run (pre-commit)


------
https://chatgpt.com/codex/tasks/task_e_687215c0f110832a926c18c23c07d88a