### PR TITLE
Add Grafana metrics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ TEL3SIS/
 
 7. **Open Grafana**
 
-   Navigate to [http://localhost:3000](http://localhost:3000) (default login `admin`/`admin`) and import `ops/grafana/tel3sis.json` via **Dashboard → Import**.
+   Visit [http://localhost:3000/d/tel3sis-latency](http://localhost:3000/d/tel3sis-latency) (default login `admin`/`admin`).
+   If the dashboard does not exist yet, import `ops/grafana/tel3sis.json` via **Dashboard → Import**.
 
 ## 📑 API Reference
 
@@ -283,7 +284,8 @@ tel3sis-maintenance prune --days 90
 * Alert rules live in `ops/prometheus/*_rules.yml` and define when latency is too high
 * Alerts trigger if STT/LLM/TTS average latency stays above **3 s** for over a minute
 * Alertmanager reads `ops/prometheus/alertmanager.yml` and posts to Slack via `SLACK_WEBHOOK_URL` in `.env`
-* Browse Grafana at [http://localhost:3000](http://localhost:3000) and import `ops/grafana/tel3sis.json` for latency graphs
+* Browse Grafana at [http://localhost:3000/d/tel3sis-latency](http://localhost:3000/d/tel3sis-latency).
+  Import `ops/grafana/tel3sis.json` if the dashboard is missing to view latency and task metrics.
 
 ---
 

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -1,0 +1,20 @@
+# Grafana Dashboard
+
+TEL3SIS ships with a preconfigured Grafana dashboard to visualize Prometheus metrics.
+
+## Access
+
+Browse to [http://localhost:3000/d/tel3sis-latency](http://localhost:3000/d/tel3sis-latency) and log in with the default `admin` / `admin` credentials.
+If the dashboard is missing, import `ops/grafana/tel3sis.json` via **Dashboard → Import**.
+
+## Panels
+
+The dashboard includes graphs for:
+
+- STT, LLM and TTS latency (95th percentile)
+- HTTP request latency
+- External API latency
+- Celery task latency
+- Task failures per minute
+
+Use the time range controls in the top right to zoom in on recent activity.

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,8 @@ TEL3SIS/
 
 7. **Open Grafana**
 
-   Navigate to [http://localhost:3000](http://localhost:3000) (default login `admin`/`admin`) and import `ops/grafana/tel3sis.json` via **Dashboard → Import**.
+   Visit [http://localhost:3000/d/tel3sis-latency](http://localhost:3000/d/tel3sis-latency) (default login `admin`/`admin`).
+   If the dashboard is missing, import `ops/grafana/tel3sis.json` via **Dashboard → Import**.
 
 ## 📑 API Reference
 
@@ -264,7 +265,8 @@ tel3sis-maintenance prune --days 90
 * Alert rules live in `ops/prometheus/*_rules.yml` and define when latency is too high
 * Alerts trigger if STT/LLM/TTS average latency stays above **3 s** for over a minute
 * Alertmanager reads `ops/prometheus/alertmanager.yml` and posts to Slack via `SLACK_WEBHOOK_URL` in `.env`
-* Browse Grafana at [http://localhost:3000](http://localhost:3000) and import `ops/grafana/tel3sis.json` for latency graphs
+* Browse Grafana at [http://localhost:3000/d/tel3sis-latency](http://localhost:3000/d/tel3sis-latency).
+  Import `ops/grafana/tel3sis.json` if the dashboard isn't present to see latency and task metrics.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: TEL3SIS
 nav:
   - Home: index.md
   - API Usage: api_usage.md
+  - Grafana Dashboard: grafana.md
   - Reviews:
       - Build, Test & Deploy Review: reviews/build_test_deploy_review.md
       - Build, Test & Deployment Review: reviews/build_test_deployment_review.md

--- a/ops/grafana/tel3sis.json
+++ b/ops/grafana/tel3sis.json
@@ -4,7 +4,9 @@
   "title": "TEL3SIS Latency",
   "schemaVersion": 37,
   "version": 1,
-  "tags": ["tel3sis"],
+  "tags": [
+    "tel3sis"
+  ],
   "time": {
     "from": "now-5m",
     "to": "now"
@@ -17,9 +19,16 @@
       "title": "STT Latency (p95)",
       "datasource": "Prometheus",
       "targets": [
-        {"expr": "histogram_quantile(0.95, rate(stt_latency_seconds_bucket[1m]))"}
+        {
+          "expr": "histogram_quantile(0.95, rate(stt_latency_seconds_bucket[1m]))"
+        }
       ],
-      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8}
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      }
     },
     {
       "id": 2,
@@ -27,9 +36,16 @@
       "title": "LLM Latency (p95)",
       "datasource": "Prometheus",
       "targets": [
-        {"expr": "histogram_quantile(0.95, rate(llm_latency_seconds_bucket[1m]))"}
+        {
+          "expr": "histogram_quantile(0.95, rate(llm_latency_seconds_bucket[1m]))"
+        }
       ],
-      "gridPos": {"x": 0, "y": 8, "w": 12, "h": 8}
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 8
+      }
     },
     {
       "id": 3,
@@ -37,9 +53,84 @@
       "title": "TTS Latency (p95)",
       "datasource": "Prometheus",
       "targets": [
-        {"expr": "histogram_quantile(0.95, rate(tts_latency_seconds_bucket[1m]))"}
+        {
+          "expr": "histogram_quantile(0.95, rate(tts_latency_seconds_bucket[1m]))"
+        }
       ],
-      "gridPos": {"x": 0, "y": 16, "w": 12, "h": 8}
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      }
+    },
+    {
+      "id": 4,
+      "type": "graph",
+      "title": "HTTP Request Latency (p95)",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(http_request_latency_seconds_bucket[1m]))"
+        }
+      ],
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      }
+    },
+    {
+      "id": 5,
+      "type": "graph",
+      "title": "External API Latency (p95)",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(external_api_latency_seconds_bucket[1m]))"
+        }
+      ],
+      "gridPos": {
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 8
+      }
+    },
+    {
+      "id": 6,
+      "type": "graph",
+      "title": "Celery Task Latency (p95)",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(celery_task_latency_seconds_bucket[1m]))"
+        }
+      ],
+      "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      }
+    },
+    {
+      "id": 7,
+      "type": "graph",
+      "title": "Task Failures per Minute",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(celery_task_failures_total[1m])"
+        }
+      ],
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 24,
+        "h": 8
+      }
     }
   ]
 }


### PR DESCRIPTION
### Task
- MON-02

### Description
- add additional Grafana panels for Prometheus metrics
- document dashboard URL and usage in docs
- link new guide in mkdocs navigation

### Checklist
- [x] Tests executed
- [x] Docs updated
- [x] CI passes


------
https://chatgpt.com/codex/tasks/task_e_6872fe1ef21c832abfdb42e7c25627de