### PR TITLE
Implement OAuth2 consent page

### DIFF
--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -48,6 +48,9 @@ Example response:
 ]
 ```
 
+### `GET /v1/oauth/consent`
+Display a consent page describing the requested Google Calendar permissions. The optional `user_id` query parameter persists through the OAuth flow.
+
 ### `GET /v1/oauth/start`
 Generate a provider authorization URL for tools like Google Calendar. Optional query parameter `user_id` identifies the requesting user. Example:
 

--- a/server/app.py
+++ b/server/app.py
@@ -50,7 +50,7 @@ from .state_manager import StateManager
 from .tasks import echo, reprocess_call, delete_call_record, process_recording
 from agents.sms_agent import SMSAgent
 from tools.notifications import send_sms
-from tools.calendar import exchange_code, generate_auth_url
+from tools.calendar import exchange_code, generate_auth_url, SCOPES
 from agents.core_agent import (
     build_core_agent,
     SafeAgentFactory,
@@ -612,6 +612,18 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     ) -> Response:
         update_agent_config(prompt=payload.prompt, voice=payload.voice)
         return Response(status_code=204)
+
+    @app.get(
+        "/v1/oauth/consent",
+        summary="Explain OAuth permissions",
+        tags=["auth"],
+    )
+    async def oauth_consent(request: Request):
+        data = OAuthStartData(**request.query_params)
+        return templates.TemplateResponse(
+            "oauth_consent.html",
+            {"request": request, "user_id": data.user_id or "", "scopes": SCOPES},
+        )
 
     @app.get("/v1/oauth/start", summary="Begin OAuth flow", tags=["auth"])
     async def oauth_start(request: Request):

--- a/server/templates/oauth_consent.html
+++ b/server/templates/oauth_consent.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Connect Google Calendar{% endblock %}
+{% block content %}
+<h1>Authorize Calendar Access</h1>
+<p>This application needs permission to manage your Google Calendar.</p>
+<ul>
+  {% for scope in scopes %}
+  <li>{{ scope }}</li>
+  {% endfor %}
+</ul>
+<form method="get" action="{{ url_for('oauth_start') }}">
+  {% if user_id %}<input type="hidden" name="user_id" value="{{ user_id }}" />{% endif %}
+  <button type="submit">Continue to Google</button>
+</form>
+{% endblock %}

--- a/tasks.yml
+++ b/tasks.yml
@@ -1944,7 +1944,7 @@ tasks:
     area: UX
     dependencies: []
     priority: 4
-    status: pending
+    status: done
     assigned_to: null
     command: null
     actionable_steps:

--- a/tests/test_oauth_consent.py
+++ b/tests/test_oauth_consent.py
@@ -1,0 +1,67 @@
+import base64
+import types
+from urllib.parse import parse_qs, urlparse
+
+import fakeredis
+from fastapi.testclient import TestClient
+
+from tests.db_utils import migrate_sqlite
+from tests.utils.vocode_mocks import install as install_vocode
+
+install_vocode()
+
+import server.app as server_app  # noqa: E402
+import server.state_manager as sm  # noqa: E402
+from server.app import create_app  # noqa: E402
+from server.config import Config  # noqa: E402
+
+
+def _setup(monkeypatch, tmp_path):
+    db = migrate_sqlite(monkeypatch, tmp_path)
+    monkeypatch.setenv("SECRET_KEY", "x")
+    monkeypatch.setenv("BASE_URL", "http://localhost")
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", base64.b64encode(b"0" * 16).decode())
+    monkeypatch.setattr(sm, "redis", types.SimpleNamespace(Redis=fakeredis.FakeRedis))
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "cid")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("OAUTH_AUTH_URL", "https://auth.example/authorize")
+    key = db.create_api_key("tester")
+    app = create_app(Config())
+    client = TestClient(app)
+    return client, key
+
+
+def test_oauth_consent_page(monkeypatch, tmp_path):
+    client, key = _setup(monkeypatch, tmp_path)
+    resp = client.get("/v1/oauth/consent?user_id=admin", headers={"X-API-Key": key})
+    assert resp.status_code == 200
+    assert "https://www.googleapis.com/auth/calendar" in resp.text
+
+
+def test_oauth_callback_stores_token(monkeypatch, tmp_path):
+    tokens = {}
+
+    class DummyStateManager(sm.StateManager):
+        def __init__(self, *args, **kwargs):
+            super().__init__(url="redis://localhost:6379/0")
+            self._redis = fakeredis.FakeRedis(decode_responses=True)
+            tokens["mgr"] = self
+
+    monkeypatch.setattr(server_app, "StateManager", DummyStateManager)
+    client, key = _setup(monkeypatch, tmp_path)
+
+    resp = client.get("/v1/login/oauth", headers={"X-API-Key": key})
+    state = parse_qs(urlparse(resp.headers["Location"]).query)["state"][0]
+
+    def fake_exchange(manager, state, url):
+        manager.set_token("admin", "tok", "rt", 1)
+
+    monkeypatch.setattr(server_app, "exchange_code", fake_exchange)
+
+    resp = client.get(
+        f"/v1/oauth/callback?state={state}&user=admin", headers={"X-API-Key": key}
+    )
+    assert resp.status_code == 302
+    assert tokens["mgr"].get_token("admin")["access_token"] == "tok"


### PR DESCRIPTION
### Task
- ID: 106 – UX-05

### Description
- add OAuth consent page template and route
- document new endpoint
- mark task complete
- add tests for consent page and token handling

### Checklist
- [x] Tests added
- [x] Docs updated
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_e_68732d2b7848832aa3a6a7200612f584