### PR TITLE
chore(tasks): update status schema

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -11,7 +11,7 @@
 #         "component": {"type": "string"},
 #         "dependencies": {"type": "array","items": {"type": "integer"}},
 #         "priority": {"type": "integer","minimum": 1, "maximum": 5},
-#         "status": {"type": "string","enum": ["pending","in_progress","done"]},
+#         "status": {"type": "string","enum": ["pending","in_progress","in_review","blocked","done"]},
 #         "command": {"type": ["string", "null"]},
 #         "task_id": {"type": "string"},
 #         "title": {"type": "string"},


### PR DESCRIPTION
## Summary
- expand tasks.yml status enumeration to include `in_review` and `blocked`

## Testing
- `pre-commit run --files tasks.yml`
- `pytest -q` *(fails: KeyError: 'Location', NoInspectionAvailable, ConnectionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68738ff3c37c832a90542530dc7057eb