### PR TITLE
docs: document mkdocs requirement for build-docs hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,13 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+The `build-docs` hook requires **MkDocs** version 1.5.3 or newer. If it isn't
+already installed, add it to your environment:
+
+```bash
+pip install "mkdocs>=1.5.3"
+```
+
 The hooks format with **Black**, lint with **Ruff**, scan with **git-secrets**, and build the docs.
 
 ## Running Tests


### PR DESCRIPTION
### Task
- ID: N/A

### Description
- Mentioned that the `build-docs` pre-commit hook depends on MkDocs v1.5.3+.
- Added installation command near the pre-commit installation instructions.

### Checklist
- [x] Docs updated
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_e_6873988d9510832a84b924506ed29e88