### PR TITLE
CI-07 automate requirements lock checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
+      - name: Check requirements lockfiles
+        run: |
+          pip-compile --quiet requirements.in
+          pip-compile --quiet requirements-dev.in
+          git diff --exit-code requirements.txt requirements-dev.txt
       - name: Install git-secrets and jq
         run: |
           sudo apt-get update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,10 @@ repos:
         language: python
         additional_dependencies: [mkdocs==1.5.3]
         pass_filenames: false
+      - id: pip-compile
+        name: pip-compile
+        entry: bash -c 'pip-compile requirements.in && pip-compile requirements-dev.in'
+        language: system
+        pass_filenames: false
+        files: ^requirements(-dev)?\.in$
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -2067,7 +2067,7 @@ tasks:
     area: CI/CD
     dependencies: [112]
     priority: 2
-    status: pending
+    status: done
     assigned_to: null
     command: null
     actionable_steps:


### PR DESCRIPTION
### Task
- ID: 113 – CI-07

### Description
Adds a local pre-commit hook that runs `pip-compile` whenever `requirements.in` files are modified. The CI workflow now verifies that the compiled lockfiles are up to date by running `pip-compile` and checking for differences. The task entry in `tasks.yml` is marked as done.

### Checklist
- [x] Tests added
- [ ] Docs updated
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_e_687456315600832aa08ad1daaaceb981