### PR TITLE
Add backup and restore CLI commands

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+import tests.test_health as _  # noqa: F401
+
+sys.modules.setdefault(
+    "scripts.dev_test_call", types.ModuleType("scripts.dev_test_call")
+)
+sys.modules.setdefault("scripts.red_team", types.ModuleType("scripts.red_team"))
+sys.modules["scripts.red_team"].load_prompts = lambda *a, **k: []
+sys.modules["scripts.red_team"].run_red_team = lambda *a, **k: []
+sys.modules["scripts.red_team"].summarize_results = lambda *a, **k: ""
+
+from click.testing import CliRunner  # noqa: E402
+from tel3sis.cli import cli  # noqa: E402
+
+
+def test_cli_backup(monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        "server.tasks.backup_data.delay",
+        lambda upload_to_s3=None: called.setdefault("s3", upload_to_s3),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["backup", "--s3"])
+    assert result.exit_code == 0
+    assert called["s3"] is True
+
+
+def test_cli_restore(monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        "server.tasks.restore_data.delay",
+        lambda archive: called.setdefault("archive", archive),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["restore", "file.tar.gz"])
+    assert result.exit_code == 0
+    assert called["archive"] == "file.tar.gz"


### PR DESCRIPTION
### Task
- ID: None

### Description
- add `backup` and `restore` subcommands to `tel3sis` CLI that enqueue
  `server.tasks.backup_data` and `server.tasks.restore_data`
- update CLI help text
- add tests verifying new commands trigger the tasks

### Checklist
- [x] Tests added
- [x] Docs updated
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_e_6874eb0ce738832a8796b566f2bffe2d