### PR TITLE
Add module docstrings for server and tools

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,3 +1,4 @@
+"""FastAPI application serving telephony and web endpoints."""
 from __future__ import annotations
 import re
 import secrets

--- a/server/cache.py
+++ b/server/cache.py
@@ -1,3 +1,5 @@
+"""Redis-backed caching utilities for function results."""
+
 import hashlib
 import json
 from functools import wraps

--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -1,3 +1,4 @@
+"""Celery application configuration for background tasks."""
 from __future__ import annotations
 from celery import Celery
 from celery.schedules import crontab

--- a/server/chat.py
+++ b/server/chat.py
@@ -1,3 +1,4 @@
+"""WebSocket connection manager for chat sessions."""
 from __future__ import annotations
 
 from typing import Dict

--- a/server/config.py
+++ b/server/config.py
@@ -1,3 +1,5 @@
+"""Compatibility layer exporting :class:`Settings` as :class:`Config`."""
+
 from .settings import Settings, ConfigError
 
 Config = Settings

--- a/server/database.py
+++ b/server/database.py
@@ -1,3 +1,4 @@
+"""Database models and helpers using SQLAlchemy."""
 from __future__ import annotations
 
 from datetime import datetime, UTC

--- a/server/fast_app.py
+++ b/server/fast_app.py
@@ -1,3 +1,4 @@
+"""Standalone FastAPI app exposing a chat WebSocket."""
 from __future__ import annotations
 
 from typing import Optional

--- a/server/handoff.py
+++ b/server/handoff.py
@@ -1,3 +1,4 @@
+"""Utility for generating TwiML used during call escalation."""
 from __future__ import annotations
 
 from xml.etree.ElementTree import Element, tostring

--- a/server/latency_logging.py
+++ b/server/latency_logging.py
@@ -1,3 +1,4 @@
+"""Decorators and helpers for latency logging and metrics."""
 from __future__ import annotations
 
 import asyncio

--- a/server/metrics.py
+++ b/server/metrics.py
@@ -1,3 +1,5 @@
+"""Prometheus metrics utilities and FastAPI middleware."""
+
 import time
 from contextlib import contextmanager
 from typing import Awaitable, Callable

--- a/server/recordings.py
+++ b/server/recordings.py
@@ -1,3 +1,4 @@
+"""Helpers for downloading and transcribing call recordings."""
 from __future__ import annotations
 
 from pathlib import Path

--- a/server/self_reflection.py
+++ b/server/self_reflection.py
@@ -1,3 +1,5 @@
+"""Generate short self-critiques for call transcripts."""
+
 from typing import Any
 
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -1,3 +1,4 @@
+"""Application settings loaded from environment variables."""
 from __future__ import annotations
 
 from pydantic import ValidationError

--- a/server/state_manager.py
+++ b/server/state_manager.py
@@ -1,3 +1,4 @@
+"""Manage call session data and OAuth tokens in Redis."""
 from __future__ import annotations
 
 import base64

--- a/server/tasks.py
+++ b/server/tasks.py
@@ -1,3 +1,4 @@
+"""Celery task implementations for background processing."""
 from __future__ import annotations
 
 from logging_config import logger

--- a/server/validation.py
+++ b/server/validation.py
@@ -1,3 +1,4 @@
+"""Helpers for consistent FastAPI validation responses."""
 from __future__ import annotations
 
 from fastapi.responses import JSONResponse

--- a/server/vector_db.py
+++ b/server/vector_db.py
@@ -1,3 +1,4 @@
+"""Wrapper around ChromaDB for semantic search storage."""
 from __future__ import annotations
 
 from typing import Iterable, List, Sequence, Optional

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,3 +1,4 @@
+"""Registry of built-in tools and selection helpers."""
 from __future__ import annotations
 
 from agents.calendar_agent import CalendarAgent

--- a/tools/base.py
+++ b/tools/base.py
@@ -1,3 +1,4 @@
+"""Abstract base classes and registry for callable tools."""
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/tools/calendar.py
+++ b/tools/calendar.py
@@ -1,3 +1,4 @@
+"""Google Calendar integration tools for event management."""
 from __future__ import annotations
 from datetime import datetime
 from typing import Any, List

--- a/tools/notifications.py
+++ b/tools/notifications.py
@@ -1,3 +1,4 @@
+"""Utility functions for sending email and SMS notifications."""
 from __future__ import annotations
 
 from pathlib import Path

--- a/tools/safety.py
+++ b/tools/safety.py
@@ -1,3 +1,4 @@
+"""Simple heuristics and OpenAI-based safety checks."""
 from __future__ import annotations
 
 import re

--- a/tools/weather.py
+++ b/tools/weather.py
@@ -1,3 +1,4 @@
+"""Tool for fetching simple weather reports."""
 from __future__ import annotations
 
 import requests


### PR DESCRIPTION
### Task
- ID: <none>

### Description
- Added concise PEP 257 style module docstrings to all modules under `server/` and `tools/` that lacked them.
- Verified formatting and linting with `ruff` and repository pre-commit hooks.

### Checklist
- [x] Tests pass
- [x] Linters pass


------
https://chatgpt.com/codex/tasks/task_e_6874feff74a4832ab2657e534b8faea3