### PR TITLE
Update backup CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,16 +258,15 @@ tel3sis manage cleanup --days 30
 
 ### Maintenance Commands
 
-These utilities provide quick access to call history and cleanup tasks. After
-installing the package with `pip install -e .`, invoke them via the console
-script or directly with Python:
+Use the CLI to create and restore backups once the project is installed with
+`pip install -e .`:
 
 ```bash
-# list recent calls
-tel3sis-maintenance list-calls
+# create a backup and upload to S3
+tel3sis backup --s3
 
-# prune calls older than 90 days
-tel3sis-maintenance prune --days 90
+# restore from an archive
+tel3sis restore backups/latest.tar.gz
 ```
 
 ---

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -4,20 +4,20 @@ TEL3SIS stores call data in SQLite and vector embeddings on disk. Regular backup
 
 ## Manual Backup
 
-Run the maintenance script to create an archive containing both the database and vector store:
+Run the `tel3sis` CLI to create an archive containing both the database and vector store:
 
 ```bash
-python -m scripts.maintenance.backup [--s3]
+tel3sis backup [--s3]
 ```
 
-The optional `--s3` flag uploads the archive to the bucket defined by `BACKUP_S3_BUCKET`.
+Use the optional `--s3` flag to upload the archive to the bucket defined by `BACKUP_S3_BUCKET`.
 
 ## Manual Restore
 
 To restore from a backup archive:
 
 ```bash
-python -m scripts.maintenance.restore path/to/backup.tar.gz
+tel3sis restore path/to/backup.tar.gz
 ```
 
 The command replaces the current database file and vector directory with the contents of the archive.
@@ -27,7 +27,7 @@ The command replaces the current database file and vector directory with the con
 Backups can be automated using **cron** or Celery beat. Example cron entry creating a nightly backup at 2am:
 
 ```cron
-0 2 * * * cd /opt/tel3sis && /usr/local/bin/python -m scripts.maintenance.backup --s3
+0 2 * * * cd /opt/tel3sis && /usr/local/bin/tel3sis backup --s3
 ```
 
 When using Celery beat, schedule the `server.tasks.backup_data` task with the desired interval.

--- a/docs/index.md
+++ b/docs/index.md
@@ -223,16 +223,15 @@ tel3sis manage cleanup --days 30
 
 ### Maintenance Commands
 
-These utilities provide quick access to call history and cleanup tasks. After
-installing the package with `pip install -e .`, invoke them via the console
-script or directly with Python:
+Create and restore backups using the CLI after installing the package with
+`pip install -e .`:
 
 ```bash
-# list recent calls
-tel3sis-maintenance list-calls
+# create a backup and upload to S3
+tel3sis backup --s3
 
-# prune calls older than 90 days
-tel3sis-maintenance prune --days 90
+# restore from an archive
+tel3sis restore backups/latest.tar.gz
 ```
 
 ---


### PR DESCRIPTION
### Task
- Replace deprecated CLI references

### Description
Updated documentation in `docs/backups.md`, `README.md`, and `docs/index.md` to reference the unified `tel3sis` CLI for backup and restore operations. Added a short note about using the `--s3` flag with example usage. Ran `pre-commit` to ensure formatting.

### Checklist
- [x] Docs updated
- [x] `pre-commit` green

------
https://chatgpt.com/codex/tasks/task_e_68750d650b84832a8b96bab4b101b009