### PR TITLE
Add drift analysis report

### DIFF
--- a/docs/reviews/drift_analysis_report.md
+++ b/docs/reviews/drift_analysis_report.md
@@ -1,0 +1,47 @@
+# Part 5 – Drift Analysis & Decision Audit Report
+
+This report captures the system state as observed during a routine audit. It outlines areas of drift, summarizes key decisions, and projects possible futures for TEL3SIS.
+
+## Drift Analysis Report
+
+- **Feature Scope vs Tasks** – Nearly all tasks in `tasks.yml` are marked done. Documentation tasks `DOCS-01` and `DOCS-02` remain `in_review`, indicating a lag in user-facing docs.
+- **Configuration Documentation** – Environment variables listed in `README.md` match `CONFIGURATION.md` and the settings modules.
+- **Process vs Implementation** – CONTRIBUTING instructions align with CI workflows; pre‑commit and security scans are enforced.
+- **Architecture Reviews & Proposed Tasks** – Design review tasks are reflected as completed in `tasks.yml`.
+- **Residual Flask References** – Legacy Flask code has been removed as required by `REF-01`.
+
+## Decision Audit Ledger
+
+| Decision | Origin | Justified by | Breaks Down If |
+|----------|-------|--------------|----------------|
+| Move to unified `Config` dataclass for env vars | Tasks `CONF-02`, README instructions | Prevent scattered `os.environ` usage and enforce validation | Startup fails if env vars are missing |
+| Add `USE_FAKE_SERVICES` flag | Feature commit and docs update | Allows tests to run offline | Could mask real integration issues if used in production |
+| Adopt pip-tools for dependencies | Review task `DEV-02` | Lock runtime vs dev requirements | Pip-compile not updated breaks builds |
+| Implement Safety Oracle pre-execution filter | Task `SAFE-01` | Prevent unsafe LLM output | Overly strict filter blocks valid responses |
+| Replace Flask with FastAPI | Task `REF-01` | Consolidate server framework | Legacy code left could cause routing conflicts |
+
+## Trajectory Assessment
+
+1. **Convergent Stability** – Remaining docs tasks close and CI continues to enforce quality.
+2. **Process Stall** – If documentation lags or tasks accumulate without updates, drift grows.
+3. **Scope Creep & Entropy** – New features outside `tasks.yml` risk structural confusion.
+
+## Schema & Structural Integrity Checks
+
+- `tasks.yml` follows its JSON schema.
+- Directory layout and imports match documentation.
+- `mkdocs.yml` indexes documentation pages coherently.
+
+## Recommendations for Realignment
+
+1. Finalize outstanding documentation tasks.
+2. Ensure tests run consistently in CI using `USE_FAKE_SERVICES` or document setup.
+3. Keep new features synchronized with `tasks.yml` and docs.
+
+## Narrative Intelligence Score
+
+7/10 – The repository tells a coherent story, though incomplete docs weaken the narrative.
+
+## Agentic Harmony Score
+
+8/10 – Roles and processes are defined, but unfinished tasks and occasional test issues reduce the score.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,4 +12,5 @@ nav:
       - Build, Test & Deployment Review: reviews/build_test_deployment_review.md
       - Interfaces & Interactions Review: reviews/interfaces_interactions_review.md
       - Core Logic Architecture Review: reviews/core_logic_architecture_review.md
+      - Drift Analysis & Decision Audit: reviews/drift_analysis_report.md
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -2170,3 +2170,21 @@ tasks:
     acceptance_criteria:
       - "All modules use the logging_config logger."
       - "Logs include relevant context for debugging."
+
+  - id: 119
+    task_id: DOCS-06
+    epic: "Documentation"
+    title: "Publish Drift Analysis Report"
+    description: "Add drift analysis and decision audit ledger to the documentation."
+    component: docs
+    area: Docs
+    dependencies: []
+    priority: 2
+    status: done
+    assigned_to: null
+    command: null
+    actionable_steps:
+      - "Create docs/reviews/drift_analysis_report.md summarizing system health."
+      - "Add entry to mkdocs.yml navigation."
+    acceptance_criteria:
+      - "Report accessible via documentation site."


### PR DESCRIPTION
## Summary
- document system drift analysis and decision audit
- include new report in mkdocs navigation
- track report in tasks

## Testing
- `pre-commit run --files mkdocs.yml tasks.yml docs/reviews/drift_analysis_report.md`
- `pytest -q` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687892dffcd0832a833845b3b0241721