### PR TITLE
Update docs tasks and add task logs

### DIFF
--- a/tasklogs/107.md
+++ b/tasklogs/107.md
@@ -1,0 +1,12 @@
+# Task 107 - DOCS-01
+
+## Summary
+OpenAPI documentation has been generated using FastAPI's schema support. The docs/api_reference.md file provides an interactive Swagger UI referencing openapi.json. All endpoints are annotated for accurate schema generation.
+
+## Execution Plan
+- Verify openapi.json exists and is up to date.
+- Ensure api_reference.md references openapi.json and is linked in mkdocs.yml.
+- Mark task status as done in tasks.yml.
+
+## Outcome
+OpenAPI documentation is accessible and complete. Task ready to mark as done.

--- a/tasklogs/108.md
+++ b/tasklogs/108.md
@@ -1,0 +1,12 @@
+# Task 108 - DOCS-02
+
+## Summary
+User guide has been added as docs/user_guide.md. It explains setup and usage for non-technical users including Twilio integration and calendar connection.
+
+## Execution Plan
+- Confirm user_guide.md covers setup steps and troubleshooting.
+- Ensure mkdocs.yml includes the page.
+- Mark task status as done in tasks.yml.
+
+## Outcome
+Documentation is available for end users. Task ready to mark as done.

--- a/tasks.yml
+++ b/tasks.yml
@@ -1961,7 +1961,7 @@ tasks:
     area: Docs
     dependencies: []
     priority: 3
-    status: in_review
+    status: done
     assigned_to: null
     command: null
     actionable_steps:
@@ -1978,7 +1978,7 @@ tasks:
     area: Docs
     dependencies: []
     priority: 3
-    status: in_review
+    status: done
     assigned_to: null
     command: null
     actionable_steps:


### PR DESCRIPTION
### Task
- ID: 107 – DOCS-01
- ID: 108 – DOCS-02

### Description
Marked the remaining documentation tasks as complete and added task logs summarizing the work done for OpenAPI docs and the user guide.

### Checklist
- [x] Tasks updated
- [x] Task logs added
- [x] `pre-commit` completed
- [ ] `pytest` (fails)


------
https://chatgpt.com/codex/tasks/task_e_687912027e24832a94c669b5d9a68515