### PR TITLE
Add docs deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install mkdocs
+      - name: Build site
+        run: mkdocs build --strict
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./site
+


### PR DESCRIPTION
### Task
- ID: N/A
### Description
Add a GitHub Actions workflow that builds the MkDocs documentation and publishes the generated site to the `gh-pages` branch whenever changes land on `main`.
### Checklist
- [ ] Tests added
- [ ] Docs updated
- [x] CI green

------
https://chatgpt.com/codex/tasks/task_e_68792feff2b8832aadf5cc04004ba4d0