### PR TITLE
Add summarize_results test

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -302,7 +302,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Conversation Log V1 Admin Conversations  Call Id  Get"
                 }
               }
@@ -335,7 +334,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Agent Status V1 Admin Agent Status Get"
                 }

--- a/tests/test_red_team.py
+++ b/tests/test_red_team.py
@@ -44,3 +44,9 @@ def test_evaluate_iteration(monkeypatch):
     assert [c[0] for c in calls] == prompts
     assert results[0]["allowed"] is True
     assert results[1]["allowed"] is False
+
+
+def test_summarize_results():
+    results = [{"allowed": True}, {"allowed": False}, {"allowed": True}]
+    summary = red_team.summarize_results(results)
+    assert summary == {"allowed": 2, "blocked": 1}


### PR DESCRIPTION
## Summary
- add a unit test for `summarize_results`
- update generated OpenAPI schema

## Testing
- `pre-commit run --files tests/test_red_team.py`
- `pytest tests/test_red_team.py::test_summarize_results -q`


------
https://chatgpt.com/codex/tasks/task_e_6882100b5480832aac60e925843a3877